### PR TITLE
Dev.small fixes

### DIFF
--- a/projects/word-weaver/src/app/app/app.component.html
+++ b/projects/word-weaver/src/app/app/app.component.html
@@ -60,7 +60,7 @@
           </mat-menu> -->
           <span class='margin-right-20 desktop-only'>|</span>
 
-          <button mat-icon-button routerLink="settings" class="d-none d-sm-inline">
+          <button class="nav-button" routerLinkActive="active" mat-icon-button routerLink="settings" class="d-none d-sm-inline">
             <fa-icon icon="cog"></fa-icon>
           </button>
           <!-- <a [matTooltip]="'ww.header.github' | translate" matTooltipPosition="before" mat-icon-button

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.html
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.html
@@ -32,7 +32,7 @@
                     [matTooltipPosition]="tooltipPosition" (click)="copyLink()">
                     <mat-icon aria-label="Copy link">link</mat-icon>
                 </button>
-                <button *ngIf="!serverless" (click)="download()" class="ui-button toolbar__tool" mat-icon-button
+                <button *ngIf="selection.view !== 'tree'" (click)="download()" class="ui-button toolbar__tool" mat-icon-button
                     [matTooltip]="'ww.pages.tableviewer.panels.conj.download-tip' | translate"
                     [matTooltipShowDelay]="showDelay.value" [matTooltipHideDelay]="hideDelay.value"
                     [matTooltipPosition]="tooltipPosition">

--- a/projects/word-weaver/src/app/shared/shared.module.ts
+++ b/projects/word-weaver/src/app/shared/shared.module.ts
@@ -116,7 +116,9 @@ import { TierComponent } from "./tier/tier.component";
     MatTableModule,
     MatExpansionModule,
     MatPaginatorModule,
-    NgxEchartsModule,
+    NgxEchartsModule.forRoot({
+      echarts: () => import("echarts")
+    }),
     FontAwesomeModule,
     MatTableExporterModule,
     ClipboardModule


### PR DESCRIPTION
This is a series of small fixes including:

1. fixing the tree view (it's not currently rendering at all due to a changed import in a newer version)
2. hiding the download button for the tree view since it's not downloadable
3. highlighting the settings cog when the settings page is active