### PR TITLE
Make validation stricter: only allow declared fields

### DIFF
--- a/projects/word-weaver-cli/README.md
+++ b/projects/word-weaver-cli/README.md
@@ -1,6 +1,6 @@
 ## Validation for data files
 
-To run:
+To run validation:
 
 ```
 cd projects/word-weaver-cli

--- a/projects/word-weaver-cli/gen-schemas.sh
+++ b/projects/word-weaver-cli/gen-schemas.sh
@@ -5,5 +5,5 @@ mkdir -p schemas
 
 for type in Options Verbs Pronouns Conjugations; do
     echo Generating the schema for $type.
-    npx typescript-json-schema package.json $type > schemas/$type.jsonschema.json
+    npx typescript-json-schema --noExtraProps package.json $type > schemas/$type.jsonschema.json
 done

--- a/projects/word-weaver/src/config/schema.ts
+++ b/projects/word-weaver/src/config/schema.ts
@@ -3,11 +3,23 @@
 // for the data only, i.e., for conjugations.json, options.json, pronouns.json
 // and verbs.json.
 
+export interface LocalizedOption {
+  tag: string;
+  type?: string;
+}
+
 export interface Option {
   classes: string[];
   gloss: string;
   tag: string;
   type?: string;
+  en: LocalizedOption;
+  fr: LocalizedOption;
+}
+
+export interface LocalizedPronoun {
+  agent: string;
+  patient: string;
 }
 
 export interface Pronoun {
@@ -20,6 +32,8 @@ export interface Pronoun {
   value: string;
   position?: Number;
   tag: string;
+  en: LocalizedPronoun;
+  fr: LocalizedPronoun;
 }
 
 export interface Verb {
@@ -27,6 +41,8 @@ export interface Verb {
   display: string;
   tag: string;
   classes: string[];
+  en: string;
+  fr: string;
 }
 
 export interface ConjugationInput {


### PR DESCRIPTION
This will force us to declare everything, including the localized languages we support, but I think that's a good thing.

I still want to figure out how to automatically make some (but not all) fields required, but this is a good step, if we declare all fields we use, that we can validate that nothing extra has been added but not declared.