### PR TITLE
fix: the z-index for the mat-accordion of the selected verbs in the table viewer

### DIFF
--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.html
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.html
@@ -26,7 +26,7 @@
           <mat-chip-list #chipList aria-label="Selected Verbs">
             <mat-chip class='mat-accent' *ngFor="let verb of selection" selectable="false" [removable]="true"
               (removed)="onVerbDeselect(verb)">
-              {{ verb[lang] }}
+              <div class="chip-text">{{ verb[lang] }}</div>
               <mat-icon matChipRemove>cancel</mat-icon>
             </mat-chip>
           </mat-chip-list>

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.scss
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.scss
@@ -39,6 +39,28 @@ button.deselect {
 .mat-accordion {
   min-width: 170px;
   max-width: 170px;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.mat-chip {
+  min-width: 100%;
+  max-width: 100%;
+}
+
+.chip-text {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  position: relative;
+  width: 80%;
+  line-height: 1;
+}
+
+.mat-icon {
+  margin: 0 !important;
+  position: absolute;
+  right: 9px;
 }
 
 // mat-icon.mat-chip-remove {


### PR DESCRIPTION
Address issue #23 

The issue was two-fold: 
- The "verb" title header was pushing the "selected verb accordion" out of the box
- The overflow of the selected verb was not addressed and was pushing itself and the cancel button out of the box.

It's difficult to test with English, but if you artificially lengthen them via the developer tools, you can see the fix. 

**Soln**
The accordion's position is now absolute. It's z-index is inherently above the title.
The text of the selected verbs get clipped with ellipses. 

For example:
![image](https://github.com/roedoejet/wordweaver-UI/assets/22920735/52f7bb40-eeaa-4bf2-8180-7d600ab50d2a)
