### PR TITLE
feat: make request for compressed language files by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "WordWeaver",
+    "name": "wordweaver",
     "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "WordWeaver",
+            "name": "wordweaver",
             "version": "1.0.0",
             "hasInstallScript": true,
             "dependencies": {

--- a/projects/word-weaver-cli/config.ts
+++ b/projects/word-weaver-cli/config.ts
@@ -1,4 +1,4 @@
-import { Verb, Option, Pronoun, Conjugations } from "./schema"
+import { Verb, Option, Pronoun, Conjugations } from "./schema";
 
 export type Options = Option[];
 export type Pronouns = Pronoun[];

--- a/projects/word-weaver/src/app/core/error-handler/app-error-handler.service.ts
+++ b/projects/word-weaver/src/app/core/error-handler/app-error-handler.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, ErrorHandler } from "@angular/core";
 import { HttpErrorResponse } from "@angular/common/http";
+import { ErrorHandler, Injectable } from "@angular/core";
 
 import { environment } from "../../../environments/environment";
 

--- a/projects/word-weaver/src/app/core/pronoun/pronoun.service.ts
+++ b/projects/word-weaver/src/app/core/pronoun/pronoun.service.ts
@@ -1,20 +1,53 @@
-import { HttpClient } from "@angular/common/http";
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse
+} from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
-import { map, shareReplay } from "rxjs/operators";
+import { Store, select } from "@ngrx/store";
+import { Observable, of, throwError } from "rxjs";
+import { catchError, map, retry, shareReplay, switchMap } from "rxjs/operators";
+
 import { Pronoun } from "../../../config/config";
-import { environment } from "../../../environments/environment";
+import { selectSettingsState } from "../core.state";
+import { SUPPRESS_ERROR } from "../http-interceptors/http-error.interceptor";
+import { SettingsState } from "../settings/settings.model";
 
 @Injectable({
   providedIn: "root"
 })
 export class PronounService {
-  path = environment.base + environment.dataPrefix + `pronouns.json`;
+  path = "pronouns.json.gz";
   pronouns: Pronoun[];
   pronouns$: Observable<Pronoun[]>;
   random$: Observable<Pronoun>;
-  constructor(private http: HttpClient) {
-    this.pronouns$ = this.http.get<Pronoun[]>(this.path).pipe(shareReplay(1));
+  suppressError = true;
+  constructor(private http: HttpClient, private store: Store) {
+    this.pronouns$ = this.store.pipe(
+      select(selectSettingsState),
+      switchMap((settings: SettingsState) =>
+        this.http.get<Pronoun[]>(settings.baseUrl + this.path, {
+          context: new HttpContext().set(SUPPRESS_ERROR, this.suppressError)
+        })
+      ),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 404 && error.url.endsWith("gz")) {
+          // Try falling back to uncompressed url
+          this.path = "pronouns.json";
+          this.suppressError = false;
+          return throwError(
+            () =>
+              new Error(
+                "compressed file not found, falling back to uncompressed version."
+              )
+          );
+        } else {
+          return throwError(() => of(error));
+        }
+      }),
+      retry(1),
+      shareReplay(1)
+    );
     this.random$ = this.pronouns$.pipe(map((res) => this.getRandomPro(res)));
     this.pronouns$.subscribe((pns) => (this.pronouns = pns));
   }

--- a/projects/word-weaver/src/app/core/verb/verb.service.ts
+++ b/projects/word-weaver/src/app/core/verb/verb.service.ts
@@ -1,20 +1,53 @@
-import { HttpClient } from "@angular/common/http";
+import {
+  HttpClient,
+  HttpContext,
+  HttpErrorResponse
+} from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { Observable } from "rxjs";
-import { map, shareReplay } from "rxjs/operators";
+import { Store, select } from "@ngrx/store";
+import { Observable, of, throwError } from "rxjs";
+import { catchError, map, retry, shareReplay, switchMap } from "rxjs/operators";
+
 import { Verb } from "../../../config/config";
-import { environment } from "../../../environments/environment";
+import { selectSettingsState } from "../core.state";
+import { SUPPRESS_ERROR } from "../http-interceptors/http-error.interceptor";
+import { SettingsState } from "../settings/settings.model";
 
 @Injectable({
   providedIn: "root"
 })
 export class VerbService {
   verbs: Verb[];
-  path = environment.base + environment.dataPrefix + `verbs.json`;
+  path = "verbs.json.gz";
   verbs$: Observable<Verb[]>;
   random$: Observable<Verb>;
-  constructor(private http: HttpClient) {
-    this.verbs$ = this.http.get<Verb[]>(this.path).pipe(shareReplay(1));
+  suppressError = true;
+  constructor(private http: HttpClient, private store: Store) {
+    this.verbs$ = this.store.pipe(
+      select(selectSettingsState),
+      switchMap((settings: SettingsState) =>
+        this.http.get<Verb[]>(settings.baseUrl + this.path, {
+          context: new HttpContext().set(SUPPRESS_ERROR, this.suppressError)
+        })
+      ),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 404 && error.url.endsWith("gz")) {
+          // Try falling back to uncompressed url
+          this.path = "verbs.json";
+          this.suppressError = false;
+          return throwError(
+            () =>
+              new Error(
+                "compressed file not found, falling back to uncompressed version."
+              )
+          );
+        } else {
+          return throwError(() => of(error));
+        }
+      }),
+      retry(1),
+      shareReplay(1)
+    );
     this.verbs$.subscribe((verbs) => (this.verbs = verbs));
     this.random$ = this.verbs$.pipe(
       map((res) => {


### PR DESCRIPTION
if tthe compressed language files are not found, we silently retry the request with the uncompressed language files.

There are a few other things here too:

- We were only re-fetching conjugations based on the whether we were using the test API or not, this changes it so that all language resources are fetched dynamically from whichever API is selected
- I added an HTTP Context Token that allows us to suppress our global error handling
- imports were not sorted properly so I sorted them