### PR TITLE
refactor(ci): run tests in one job, but let them all run before failing on any error

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Run tests
 on: [push]
 jobs:
-  spec-tests:
+  all-tests:
     runs-on: ubuntu-latest
     # Stop the occasional rogue instance before the 6h GitHub limit
     timeout-minutes: 15
@@ -14,32 +14,41 @@ jobs:
           node-version: 18
       - name: Install everything
         run: npm install
-      - name: Run lint and spec tests
-        run: npm run-script ci:test
+
+      - name: Run spec tests
+        id: specs
+        continue-on-error: true
+        run: npm run-script ci:test || echo "exit_code=$?" >> $GITHUB_OUTPUT
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  e2e-tests:
-    runs-on: ubuntu-latest
-    # Stop the occasional rogue instance before the 6h GitHub limit
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js 18
-        uses: actions/setup-node@v3
         with:
-          node-version: 18
-      - name: Install everything
-        run: npm install
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Run ng lint
+        id: lint
+        continue-on-error: true
+        run: npm run-script lint || echo "exit_code=$?" >> $GITHUB_OUTPUT
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx npm run-script e2e
+        id: e2e
+        continue-on-error: true
+        run: npx npm run-script e2e || echo "exit_code=$?" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
-        if: always()
+        if: steps.e2e.outputs.exit_code == ''
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - name: check that all validation passed
+        run: |
+          if [[ "${{ steps.specs.outputs.exit_code }}" != "" || \
+                "${{ steps.e2e.outputs.exit_code }}" != "" || \
+                "${{ steps.lint.outputs.exit_code }}" != "" ]]; then \
+            echo ERROR: at least one kind of validation failed, see logs above; \
+            false; \
+          fi
+          echo All tests passed.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,8 +18,9 @@ jobs:
       - name: Run spec tests
         id: specs
         continue-on-error: true
-        run: npm run-script ci:test || echo "exit_code=$?" >> $GITHUB_OUTPUT
+        run: npm run-script ci:test
       - name: Upload coverage reports to Codecov
+        if: steps.specs.outcome == 'success'
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
@@ -28,27 +29,23 @@ jobs:
       - name: Run ng lint
         id: lint
         continue-on-error: true
-        run: npm run-script lint || echo "exit_code=$?" >> $GITHUB_OUTPUT
+        run: npm run-script lint
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         id: e2e
         continue-on-error: true
-        run: npx npm run-script e2e || echo "exit_code=$?" >> $GITHUB_OUTPUT
+        run: npx npm run-script e2e
       - uses: actions/upload-artifact@v3
-        if: steps.e2e.outputs.exit_code == ''
+        if: steps.e2e.outcome == 'success'
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
 
-      - name: check that all validation passed
+      - name: Fail if any previous test failed
+        if: steps.specs.outcome == 'failure' || steps.lint.outputs.outcome == 'failure' || steps.e2e.outputs.outcome == 'failure'
         run: |
-          if [[ "${{ steps.specs.outputs.exit_code }}" != "" || \
-                "${{ steps.e2e.outputs.exit_code }}" != "" || \
-                "${{ steps.lint.outputs.exit_code }}" != "" ]]; then \
-            echo ERROR: at least one kind of validation failed, see logs above; \
-            false; \
-          fi
-          echo All tests passed.
+          echo ERROR: at least one validation step failed, see logs of earlier steps above
+          false

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build-toy": "ng build --outputPath ./dist_toy",
     "lint": "ng lint",
     "test": "ng lint && ng test --configuration=test",
-    "ci:test": "ng lint && ng test --browsers=ChromeHeadless --watch=false --configuration=test",
+    "ci:test": "ng test --browsers=ChromeHeadless --watch=false --configuration=test",
     "watch": "ng test --configuration=test --browsers ChromeHeadless --watch --reporters dots",
     "release": "standard-version && git push --follow-tags origin master",
     "format:write": "prettier projects/**/*.{ts,json,md,scss,html} --write",


### PR DESCRIPTION
This solution runs all the tests in a single job, even if previous ones failed
 - specs
 - lint
 - e2e
 - validate and compress (coming in a future PR)

The idea is to do the installation just once.

Question of philosophy: this saves a good minutes of shared setup per job, and otherwise we would probably have three jobs by the time I was done validate. But it increases the code complexity. Is it worth it?

I also spliced lint out of ci:test in package.json, because I want to see the test output even when ng lint fails.