### PR TITLE
refactor: use the full "marker" rather than the obscure "_"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "contributors:generate": "all-contributors generate && node .all-contributors-html.js",
     "contributors:check": "all-contributors check",
     "tslint-check": "tslint-config-prettier-check ./tslint.json",
-    "extract-translations": "ngx-translate-extract --input ./projects/word-weaver/src --output ./projects/word-weaver/src/assets/i18n/*.json --sort --format namespaced-json --null-as-default-value --marker _",
+    "extract-translations": "ngx-translate-extract --input ./projects/word-weaver/src --output ./projects/word-weaver/src/assets/i18n/*.json --sort --format namespaced-json --null-as-default-value && prettier --write ./projects/word-weaver/src/assets/i18n/*.json",
     "update-translations": "./update_translations.sh",
     "postinstall": "ngcc",
     "compress": "cd ./projects/word-weaver-cli && npm run-script compress",

--- a/projects/word-weaver/src/app/app/app.component.ts
+++ b/projects/word-weaver/src/app/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { select, Store } from "@ngrx/store";
 import browser from "browser-detect";
 import { Observable } from "rxjs";
@@ -33,14 +33,14 @@ export class AppComponent implements OnInit {
   logo = META_DATA.logo;
   languages = META_DATA.languages;
   navigation = [
-    { link: "wordmaker", label: _("ww.menu.wordmaker") },
-    { link: "tableviewer", label: _("ww.menu.tableviewer") },
-    // { link: "info", label: _("ww.menu.info") },
-    { link: "about", label: _("ww.menu.about") },
+    { link: "wordmaker", label: marker("ww.menu.wordmaker") },
+    { link: "tableviewer", label: marker("ww.menu.tableviewer") },
+    // { link: "info", label: marker("ww.menu.info") },
+    { link: "about", label: marker("ww.menu.about") },
   ];
   navigationSideMenu = [
     ...this.navigation,
-    { link: "settings", label: _("ww.menu.settings") },
+    { link: "settings", label: marker("ww.menu.settings") },
   ];
   metaData = META_DATA;
   stickyHeader$: Observable<boolean>;

--- a/projects/word-weaver/src/app/core/error-handler/app-error-handler.service.ts
+++ b/projects/word-weaver/src/app/core/error-handler/app-error-handler.service.ts
@@ -5,7 +5,7 @@ import { environment } from "../../../environments/environment";
 
 import { NotificationService } from "../notifications/notification.service";
 
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 
 /** Application-wide error handler that adds a UI notification to the error handling
  * provided by the default Angular ErrorHandler.
@@ -20,9 +20,9 @@ export class AppErrorHandler extends ErrorHandler {
     let displayMessage;
 
     if (!environment.production) {
-      displayMessage = _("ww.common.notifications.error.dev");
+      displayMessage = marker("ww.common.notifications.error.dev");
     } else {
-      displayMessage = _("ww.common.notifications.error.general");
+      displayMessage = marker("ww.common.notifications.error.general");
     }
 
     this.notificationsService.translated(displayMessage, {}, "error");

--- a/projects/word-weaver/src/app/core/settings/settings.effects.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.effects.ts
@@ -1,6 +1,6 @@
 import { OverlayContainer } from "@angular/cdk/overlay";
 import { Injectable } from "@angular/core";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { Actions, createEffect, ofType } from "@ngrx/effects";
 import { select, Store } from "@ngrx/store";
 import { TranslateService } from "@ngx-translate/core";
@@ -80,7 +80,7 @@ export class SettingsEffects {
             // Change to opt-in
             this.localStorageService.removeItem("plausible_ignore");
             this.notificationService.translated(
-              _("ww.pages.settings.notifications.analytics.opt-in"),
+              marker("ww.pages.settings.notifications.analytics.opt-in"),
               {},
               "success"
             );
@@ -88,7 +88,7 @@ export class SettingsEffects {
             // Change to opt-out
             this.localStorageService.setItem("plausible_ignore", "true");
             this.notificationService.translated(
-              _("ww.pages.settings.notifications.analytics.opt-out"),
+              marker("ww.pages.settings.notifications.analytics.opt-out"),
               {},
               "error"
             );

--- a/projects/word-weaver/src/app/core/tableviewer-selection/tableviewer-selection.effects.ts
+++ b/projects/word-weaver/src/app/core/tableviewer-selection/tableviewer-selection.effects.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { Actions, createEffect, ofType } from "@ngrx/effects";
 import { select, Store } from "@ngrx/store";
 import { of } from "rxjs";
@@ -74,7 +74,7 @@ export class TableviewerEffects {
         tap(([action, selection]) => {
           if (selection.root.length < 1) {
             this.notificationService.translated(
-              _("ww.pages.tableviewer.notifications.error.missing-root"),
+              marker("ww.pages.tableviewer.notifications.error.missing-root"),
               {},
               "error"
             );

--- a/projects/word-weaver/src/app/core/wordmaker-selection/wordmaker-selection.effects.ts
+++ b/projects/word-weaver/src/app/core/wordmaker-selection/wordmaker-selection.effects.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { Actions, createEffect, ofType } from "@ngrx/effects";
 import { select, Store } from "@ngrx/store";
 import { tap, withLatestFrom } from "rxjs/operators";
@@ -88,7 +88,7 @@ export class WordmakerEffects {
                 const random = randomX(this.verbService.verbs);
                 this.store.dispatch(actionChangeVerb({ root: random }));
                 this.notificationService.translated(
-                  _("ww.pages.wordmaker.notifications.random.verb"),
+                  marker("ww.pages.wordmaker.notifications.random.verb"),
                   {
                     value: this.translate.instant(
                       "ww-data.verbs." + random.tag
@@ -191,7 +191,7 @@ export class WordmakerEffects {
               if (pronoun.agent && pronoun.patient) {
                 if (!selection.agent || !selection.patient) {
                   this.notificationService.translated(
-                    _(
+                    marker(
                       "ww.pages.wordmaker.notifications.random.pers.transitive"
                     ),
                     {
@@ -208,7 +208,7 @@ export class WordmakerEffects {
               } else if (pronoun.agent) {
                 if (!selection.agent) {
                   this.notificationService.translated(
-                    _(
+                    marker(
                       "ww.pages.wordmaker.notifications.random.pers.intransitive"
                     ),
                     {
@@ -222,7 +222,7 @@ export class WordmakerEffects {
               } else if (pronoun.patient) {
                 if (!selection.patient) {
                   this.notificationService.translated(
-                    _(
+                    marker(
                       "ww.pages.wordmaker.notifications.random.pers.intransitive"
                     ),
                     {
@@ -242,7 +242,7 @@ export class WordmakerEffects {
                 const random = randomX(this.optionService.options);
                 this.store.dispatch(actionChangeOption({ option: random }));
                 this.notificationService.translated(
-                  _("ww.pages.wordmaker.notifications.random.temp"),
+                  marker("ww.pages.wordmaker.notifications.random.temp"),
                   {
                     value: this.translate.instant(
                       "ww-data.options.items." + random.tag

--- a/projects/word-weaver/src/app/i18n/i18n.ts
+++ b/projects/word-weaver/src/app/i18n/i18n.ts
@@ -1,21 +1,21 @@
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 
 // Tiers
 // This is how they should eventually be internationalized
-_("ww.pages.settings.general.tiers.display");
-_("ww.pages.settings.general.tiers.breakdown");
-_("ww.pages.settings.general.tiers.gloss");
-_("ww.pages.settings.general.tiers.breakdown-translation");
-_("ww.pages.settings.general.tiers.translation");
+marker("ww.pages.settings.general.tiers.display");
+marker("ww.pages.settings.general.tiers.breakdown");
+marker("ww.pages.settings.general.tiers.gloss");
+marker("ww.pages.settings.general.tiers.breakdown-translation");
+marker("ww.pages.settings.general.tiers.translation");
 
 // Tiers
 // Moh
-_("ww.pages.settings.general.highlighting.aspect");
-_("ww.pages.settings.general.highlighting.post-aspectual");
-_("ww.pages.settings.general.highlighting.pronouns");
-_("ww.pages.settings.general.highlighting.required");
-_("ww.pages.settings.general.highlighting.temp");
-_("ww.pages.settings.general.highlighting.verb");
+marker("ww.pages.settings.general.highlighting.aspect");
+marker("ww.pages.settings.general.highlighting.post-aspectual");
+marker("ww.pages.settings.general.highlighting.pronouns");
+marker("ww.pages.settings.general.highlighting.required");
+marker("ww.pages.settings.general.highlighting.temp");
+marker("ww.pages.settings.general.highlighting.verb");
 // Fr
-_("ww.pages.settings.general.highlighting.ending");
-_("ww.pages.settings.general.highlighting.root");
+marker("ww.pages.settings.general.highlighting.ending");
+marker("ww.pages.settings.general.highlighting.root");

--- a/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.ts
+++ b/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.ts
@@ -4,7 +4,7 @@ import {
   OnDestroy,
   OnInit,
 } from "@angular/core";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { select, Store } from "@ngrx/store";
 import { Observable, Subject } from "rxjs";
 import { take } from "rxjs/operators";
@@ -39,38 +39,38 @@ export class SettingsContainerComponent implements OnDestroy, OnInit {
   deferredPrompt$: Observable<any>;
   usesAnalytics = !!environment.plausibleAnalyticsDataDomain;
   themes = [
-    { value: "DEFAULT-THEME", label: _("ww.pages.settings.themes.blue") },
-    { value: "LIGHT-THEME", label: _("ww.pages.settings.themes.light") },
-    { value: "DARK-THEME", label: _("ww.pages.settings.themes.dark") },
+    { value: "DEFAULT-THEME", label: marker("ww.pages.settings.themes.blue") },
+    { value: "LIGHT-THEME", label: marker("ww.pages.settings.themes.light") },
+    { value: "DARK-THEME", label: marker("ww.pages.settings.themes.dark") },
     {
       value: "PURPLE-THEME--LIGHT",
-      label: _("ww.pages.settings.themes.purple-light"),
+      label: marker("ww.pages.settings.themes.purple-light"),
     },
     {
       value: "PURPLE-THEME--DARK",
-      label: _("ww.pages.settings.themes.purple-dark"),
+      label: marker("ww.pages.settings.themes.purple-dark"),
     },
     {
       value: "PURPLE-BLUE-THEME--LIGHT",
-      label: _("ww.pages.settings.themes.purple-blue-light"),
+      label: marker("ww.pages.settings.themes.purple-blue-light"),
     },
     {
       value: "PURPLE-BLUE-THEME--DARK",
-      label: _("ww.pages.settings.themes.purple-blue-dark"),
+      label: marker("ww.pages.settings.themes.purple-blue-dark"),
     },
     {
       value: "PURPLE-GOLD-THEME--LIGHT",
-      label: _("ww.pages.settings.themes.purple-gold-light"),
+      label: marker("ww.pages.settings.themes.purple-gold-light"),
     },
     {
       value: "PURPLE-GOLD-THEME--DARK",
-      label: _("ww.pages.settings.themes.purple-gold-dark"),
+      label: marker("ww.pages.settings.themes.purple-gold-dark"),
     },
   ];
 
   languages = META_DATA.languages.map((x) => ({
     value: x.value,
-    label: _(`ww.pages.settings.general.language.${x.value}`),
+    label: marker(`ww.pages.settings.general.language.${x.value}`),
   }));
   showInstall = false;
   unsubscribe$ = new Subject<void>();

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.ts
@@ -10,7 +10,7 @@ import {
 import { saveAs } from "file-saver-es";
 import { FormControl } from "@angular/forms";
 import { MatDialog, MatDialogConfig } from "@angular/material/dialog";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { select, Store } from "@ngrx/store";
 import { EChartsOption } from "echarts";
 import { TranslateService } from "@ngx-translate/core";
@@ -157,7 +157,9 @@ export class TableviewerConjPanelComponent
         if (treeState.view === "tree" && conjugationsLength > 0) {
           if (conjugationsLength > 50) {
             this.notificationService.translated(
-              _("ww.pages.tableviewer.notifications.treeviewer-length.error"),
+              marker(
+                "ww.pages.tableviewer.notifications.treeviewer-length.error"
+              ),
               { value: conjugationsLength },
               "error"
             );
@@ -201,7 +203,7 @@ export class TableviewerConjPanelComponent
     this.gridData$.pipe(take(1)).subscribe((gridData) => {
       if (gridData.uniqueRow.length > 80) {
         this.notificationService.translated(
-          _("ww.pages.tableviewer.notifications.gridOrder.limit-error"),
+          marker("ww.pages.tableviewer.notifications.gridOrder.limit-error"),
           { value: gridData.uniqueRow.length },
           "error"
         );
@@ -424,13 +426,13 @@ export class TableviewerConjPanelComponent
       );
       if (result) {
         this.notificationService.translated(
-          _("ww.pages.tableviewer.notifications.copy.success"),
+          marker("ww.pages.tableviewer.notifications.copy.success"),
           {},
           "success"
         );
       } else {
         this.notificationService.translated(
-          _("ww.pages.tableviewer.notifications.copy.error"),
+          marker("ww.pages.tableviewer.notifications.copy.error"),
           {},
           "error"
         );
@@ -441,13 +443,13 @@ export class TableviewerConjPanelComponent
   updateToast(success?, code = 200) {
     if (success) {
       this.notificationService.translated(
-        _("ww.pages.tableviewer.notifications.download.success"),
+        marker("ww.pages.tableviewer.notifications.download.success"),
         {},
         "success"
       );
     } else {
       this.notificationService.translated(
-        _("ww.pages.tableviewer.notifications.download.error"),
+        marker("ww.pages.tableviewer.notifications.download.error"),
         {},
         "error"
       );

--- a/projects/word-weaver/src/app/pages/wordmaker/wordmaker/wordmaker.component.ts
+++ b/projects/word-weaver/src/app/pages/wordmaker/wordmaker/wordmaker.component.ts
@@ -14,7 +14,7 @@ import {
   State,
 } from "../../../core/wordmaker-selection/wordmaker-selection.model";
 import { Store, select } from "@ngrx/store";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { actionChangeStep } from "../../../core/wordmaker-selection/wordmaker-selection.actions";
 import { distinctUntilKeyChanged, take, takeUntil } from "rxjs/operators";
 import { TranslateService } from "@ngx-translate/core";
@@ -31,13 +31,13 @@ export class WordmakerComponent implements OnDestroy, OnInit, AfterViewInit {
   loading;
   isLinear = true;
   verbLabel = new BehaviorSubject<string>(
-    _("ww.pages.wordmaker.steps.verb.question")
+    marker("ww.pages.wordmaker.steps.verb.question")
   );
   persLabel = new BehaviorSubject<string>(
-    _("ww.pages.wordmaker.steps.pers.question")
+    marker("ww.pages.wordmaker.steps.pers.question")
   );
   tempLabel = new BehaviorSubject<string>(
-    _("ww.pages.wordmaker.steps.temp.question")
+    marker("ww.pages.wordmaker.steps.temp.question")
   );
   selection$: Observable<WordmakerState>;
   unsubscribe$ = new Subject<void>();

--- a/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.ts
+++ b/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.ts
@@ -2,7 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { ChangeDetectionStrategy, Component, OnInit } from "@angular/core";
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import { MatDialogRef } from "@angular/material/dialog";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { select, Store } from "@ngrx/store";
 import { TranslateService } from "@ngx-translate/core";
 import { saveAs } from "file-saver-es";
@@ -50,7 +50,9 @@ export class DownloadDialogComponent implements OnInit {
   ) {
     this.translate
       .get(
-        _("ww.pages.tableviewer.dialog.download.settings.heading.placeholder")
+        marker(
+          "ww.pages.tableviewer.dialog.download.settings.heading.placeholder"
+        )
       )
       .subscribe((x) => this.form.controls.heading.setValue(x));
   }
@@ -107,7 +109,7 @@ export class DownloadDialogComponent implements OnInit {
               .pipe(
                 catchError((err) => {
                   this.notificationService.translated(
-                    _("ww.pages.tableviewer.notifications.download.error"),
+                    marker("ww.pages.tableviewer.notifications.download.error"),
                     {},
                     "error"
                   );

--- a/projects/word-weaver/src/app/shared/mat.paginator.i18n.ts
+++ b/projects/word-weaver/src/app/shared/mat.paginator.i18n.ts
@@ -1,5 +1,5 @@
 import { MatPaginatorIntl } from "@angular/material/paginator";
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { TranslateParser, TranslateService } from "@ngx-translate/core";
 
 export class WWPaginatorIntl extends MatPaginatorIntl {
@@ -17,12 +17,12 @@ export class WWPaginatorIntl extends MatPaginatorIntl {
   getTranslations() {
     this.translateService
       .get([
-        _("ww.paginator.items_per_page"),
-        _("ww.paginator.next_page"),
-        _("ww.paginator.previous_page"),
-        _("ww.paginator.first_page"),
-        _("ww.paginator.last_page"),
-        _("ww.paginator.range"),
+        marker("ww.paginator.items_per_page"),
+        marker("ww.paginator.next_page"),
+        marker("ww.paginator.previous_page"),
+        marker("ww.paginator.first_page"),
+        marker("ww.paginator.last_page"),
+        marker("ww.paginator.range"),
       ])
       .subscribe((translation) => {
         this.itemsPerPageLabel = translation["ww.paginator.items_per_page"];

--- a/projects/word-weaver/src/config/config.fr.ts
+++ b/projects/word-weaver/src/config/config.fr.ts
@@ -1,4 +1,4 @@
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { SettingsState } from "../app/core/settings/settings.model";
 import { TableviewerState } from "../app/core/tableviewer-selection/tableviewer-selection.model";
 import { Contributor } from "../app/pages/about/about/about.component";
@@ -255,31 +255,31 @@ export interface Theme {
 }
 
 export const THEMES: Theme[] = [
-  { value: "DEFAULT-THEME", label: _("ww.pages.settings.themes.default") },
-  { value: "LIGHT-THEME", label: _("ww.pages.settings.themes.light") },
-  { value: "DARK-THEME", label: _("ww.pages.settings.themes.dark") },
+  { value: "DEFAULT-THEME", label: marker("ww.pages.settings.themes.default") },
+  { value: "LIGHT-THEME", label: marker("ww.pages.settings.themes.light") },
+  { value: "DARK-THEME", label: marker("ww.pages.settings.themes.dark") },
   {
     value: "PURPLE-THEME--LIGHT",
-    label: _("ww.pages.settings.themes.purple-light"),
+    label: marker("ww.pages.settings.themes.purple-light"),
   },
   {
     value: "PURPLE-THEME--DARK",
-    label: _("ww.pages.settings.themes.purple-dark"),
+    label: marker("ww.pages.settings.themes.purple-dark"),
   },
   {
     value: "PURPLE-BLUE-THEME--LIGHT",
-    label: _("ww.pages.settings.themes.purple-blue-light"),
+    label: marker("ww.pages.settings.themes.purple-blue-light"),
   },
   {
     value: "PURPLE-BLUE-THEME--DARK",
-    label: _("ww.pages.settings.themes.purple-blue-dark"),
+    label: marker("ww.pages.settings.themes.purple-blue-dark"),
   },
   {
     value: "PURPLE-GOLD-THEME--LIGHT",
-    label: _("ww.pages.settings.themes.purple-gold-light"),
+    label: marker("ww.pages.settings.themes.purple-gold-light"),
   },
   {
     value: "PURPLE-GOLD-THEME--DARK",
-    label: _("ww.pages.settings.themes.purple-gold-dark"),
+    label: marker("ww.pages.settings.themes.purple-gold-dark"),
   },
 ];

--- a/projects/word-weaver/src/config/config.ts
+++ b/projects/word-weaver/src/config/config.ts
@@ -1,4 +1,4 @@
-import { marker as _ } from "@colsen1991/ngx-translate-extract-marker";
+import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { SettingsState } from "../app/core/settings/settings.model";
 import { TableviewerState } from "../app/core/tableviewer-selection/tableviewer-selection.model";
 import { Contributor } from "../app/pages/about/about/about.component";
@@ -263,38 +263,38 @@ export interface Theme {
 export const THEMES: Theme[] = [
   {
     value: "DEFAULT-THEME",
-    label: _("ww.pages.settings.themes.default"),
+    label: marker("ww.pages.settings.themes.default"),
   },
   {
     value: "LIGHT-THEME",
-    label: _("ww.pages.settings.themes.light"),
+    label: marker("ww.pages.settings.themes.light"),
   },
   {
     value: "DARK-THEME",
-    label: _("ww.pages.settings.themes.dark"),
+    label: marker("ww.pages.settings.themes.dark"),
   },
   {
     value: "PURPLE-THEME--LIGHT",
-    label: _("ww.pages.settings.themes.purple-light"),
+    label: marker("ww.pages.settings.themes.purple-light"),
   },
   {
     value: "PURPLE-THEME--DARK",
-    label: _("ww.pages.settings.themes.purple-dark"),
+    label: marker("ww.pages.settings.themes.purple-dark"),
   },
   {
     value: "PURPLE-BLUE-THEME--LIGHT",
-    label: _("ww.pages.settings.themes.purple-blue-light"),
+    label: marker("ww.pages.settings.themes.purple-blue-light"),
   },
   {
     value: "PURPLE-BLUE-THEME--DARK",
-    label: _("ww.pages.settings.themes.purple-blue-dark"),
+    label: marker("ww.pages.settings.themes.purple-blue-dark"),
   },
   {
     value: "PURPLE-GOLD-THEME--LIGHT",
-    label: _("ww.pages.settings.themes.purple-gold-light"),
+    label: marker("ww.pages.settings.themes.purple-gold-light"),
   },
   {
     value: "PURPLE-GOLD-THEME--DARK",
-    label: _("ww.pages.settings.themes.purple-gold-dark"),
+    label: marker("ww.pages.settings.themes.purple-gold-dark"),
   },
 ];


### PR DESCRIPTION
It's the `--marker _` option to `ngx-translate-extract` that forces aliasing `marker as _`, if we take that out we can revert to the regular `marker()` syntax.