### PR TITLE
fix: remove second exclamation mark in "Congratulations!!"

### DIFF
--- a/projects/word-weaver/src/app/pages/wordmaker/wordmaker-conj-step/wordmaker-conj-step.component.html
+++ b/projects/word-weaver/src/app/pages/wordmaker/wordmaker-conj-step/wordmaker-conj-step.component.html
@@ -9,7 +9,7 @@
         <p class="margin-0 font-lg">
           {{
             "ww.pages.wordmaker.steps.conj.congratulations-header" | translate
-          }}!
+          }}
         </p>
       </div>
       <div class="row">


### PR DESCRIPTION
I thought there would be a few "trivial" things to fix while reviewing Issues on GH, but this is the only quick one, so here's a tiny PR for it.