### PR TITLE
Make CI compression check robust to binary diffences

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install everything
         run: npm install
 
-      - name: Validation Step Run spec tests
+      - name: Check1 Run spec tests
         id: specs
         continue-on-error: true
         run: npm run-script ci:test
@@ -26,18 +26,18 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Validation Step Run ng lint
+      - name: Check2 Run ng lint
         id: lint
         continue-on-error: true
         run: npm run-script lint
 
-      - name: Validation Step Validate data
+      - name: Check3 Validate data
         id: validate
         continue-on-error: true
         run: |
           npm run-script generate-schemas
           npm run-script validate
-      - name: Validation Step Check compressed data files
+      - name: Check4 Check compressed data files
         if: steps.validate.outcome == 'success'
         id: compress
         continue-on-error: true
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - name: Validation Step Run Playwright tests
+      - name: Check5 Run Playwright tests
         id: e2e
         continue-on-error: true
         run: npx npm run-script e2e
@@ -70,12 +70,12 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-      - name: Fail if any Validation Step failed
+      - name: Fail if any Check step failed
         if: steps.specs.outcome == 'failure' || steps.lint.outcome == 'failure' || steps.validate.outcome == 'failure' || steps.compress.outcome == 'failure' || steps.e2e.outcome == 'failure'
         run: |
-          if [[ "${{ steps.specs.outcome }}" == failure ]]; then echo ERROR: Validation Step Run spec tests failed; fi
-          if [[ "${{ steps.lint.outcome }}" == failure ]]; then echo ERROR: Validation Step Run ng lint failed; fi
-          if [[ "${{ steps.validate.outcome }}" == failure ]]; then echo ERROR: Validation Step Validate data failed; fi
-          if [[ "${{ steps.compress.outcome }}" == failure ]]; then echo ERROR: Validation Step Check compressed data files failed; fi
-          if [[ "${{ steps.e2e.outcome }}" == failure ]]; then echo ERROR: Validation Step Run Playwright tests failed; fi
+          if [[ "${{ steps.specs.outcome }}" == failure ]]; then echo ERROR: Check1 Run spec tests failed; fi
+          if [[ "${{ steps.lint.outcome }}" == failure ]]; then echo ERROR: Check2 Run ng lint failed; fi
+          if [[ "${{ steps.validate.outcome }}" == failure ]]; then echo ERROR: Check3 Validate data failed; fi
+          if [[ "${{ steps.compress.outcome }}" == failure ]]; then echo ERROR: Check4 Check compressed data files failed; fi
+          if [[ "${{ steps.e2e.outcome }}" == failure ]]; then echo ERROR: Check5 Run Playwright tests failed; fi
           false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,14 @@ jobs:
         continue-on-error: true
         run: |
           npm run-script compress fr v1
-          if git status --porcelain=v1 | grep '\.json\.gz'; then \
+          ALL_OK=1; \
+          for file in $(git status --porcelain=v1 | grep '\.json\.gz' | cut -c4-); do \
+            if ! diff -q <(git show HEAD:$file 2> /dev/null | gunzip -f) <(zcat $file); then \
+              echo Error: "$file needs to be (re-)compressed and committed."; \
+              ALL_OK=0; \
+            fi; \
+          done; \
+          if [[ $ALL_OK == 0 ]]; then \
             echo Error: Please run \"npm run-script compress fr v1\" and commit the .json.gz files created or updated.; \
             false; \
           else \

--- a/projects/word-weaver-cli/compress.sh
+++ b/projects/word-weaver-cli/compress.sh
@@ -33,11 +33,7 @@ for file_base in verbs options pronouns conjugations; do
         else
             echo -n "Compressing $file_name... "
         fi
-        # Note: we use "cat $file_name | gzip" instead of "gzip < $file_name"
-        # because in the latter case, the .gz file will encode the timestamp,
-        # which we don't want because we want stable file contents even in .gz
-        # format.
-        if cat "$file_name" | gzip -9 > "$file_name.gz"; then
+        if gzip -9 --no-name < "$file_name" > "$file_name.gz"; then
             echo OK
         else
             echo ERROR: error running gzip command


### PR DESCRIPTION
Ass commented in #79, it turns out the assumption that we can make gzip output actually stable in all circumstances is actually faulty. So now let's use `gzip --no-name`, which removes filename and timestamp from the output, for *mostly* but not completely stable output, and then let's diff the actual uncompressed contents in CI so that it's only an error when the contents differ, not when the compressed files differ.

Also made the log messages clearer because I kept misreading them.

This PR replaces #79.