### PR TITLE
build: remove ts-node dependencies that we not longer use

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,6 @@
         "typescript": "4.8.4",
         "uuid": "^3.4.0",
         "v8-to-istanbul": "^9.1.3",
-        "wait-on": "4.0.0",
         "webdriver-manager": "12.1.7",
         "webpack-bundle-analyzer": "^4.9.0",
         "word-weaver-cli": "file:projects/word-weaver-cli",
@@ -4228,58 +4227,6 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
-    },
-    "node_modules/@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
-      "deprecated": "Moved to 'npm install @sideway/address'",
-      "dev": true
-    },
-    "node_modules/@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
-      "deprecated": "Moved to 'npm install @sideway/formula'",
-      "dev": true
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
-      "deprecated": "This version has been deprecated and is no longer supported or maintained",
-      "dev": true
-    },
-    "node_modules/@hapi/joi": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-      "deprecated": "Switch to 'npm install joi'",
-      "dev": true,
-      "dependencies": {
-        "@hapi/address": "^2.1.2",
-        "@hapi/formula": "^1.2.0",
-        "@hapi/hoek": "^8.2.4",
-        "@hapi/pinpoint": "^1.0.2",
-        "@hapi/topo": "^3.1.3"
-      }
-    },
-    "node_modules/@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
-      "deprecated": "Moved to 'npm install @sideway/pinpoint'",
-      "dev": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
-      "deprecated": "This version has been deprecated and is no longer supported or maintained",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^8.3.0"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
@@ -21638,39 +21585,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
-    "node_modules/request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
-      "dev": true,
-      "dependencies": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      },
-      "peerDependencies": {
-        "request": "^2.34"
-      }
-    },
     "node_modules/request/node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -23401,15 +23315,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -25144,26 +25049,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wait-on": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-4.0.0.tgz",
-      "integrity": "sha512-QrW3J8LzS5ADPfD9Rx5S6KJck66xkqyiFKQs9jmUTkIhiEOmkzU7WRZc+MjsnmkrgjitS2xQ4bb13hnlQnKBUQ==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/joi": "^16.1.8",
-        "lodash": "^4.17.15",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.8",
-        "rxjs": "^6.5.4"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/walkdir": {
@@ -29329,52 +29214,6 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
-    },
-    "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
-      "dev": true
-    },
-    "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
-      "dev": true
-    },
-    "@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
-      "dev": true
-    },
-    "@hapi/joi": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-      "dev": true,
-      "requires": {
-        "@hapi/address": "^2.1.2",
-        "@hapi/formula": "^1.2.0",
-        "@hapi/hoek": "^8.2.4",
-        "@hapi/pinpoint": "^1.0.2",
-        "@hapi/topo": "^3.1.3"
-      }
-    },
-    "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
-      "dev": true
-    },
-    "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^8.3.0"
-      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.13",
@@ -42415,26 +42254,6 @@
         }
       }
     },
-    "request-promise-core": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.19"
-      }
-    },
-    "request-promise-native": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "dev": true,
-      "requires": {
-        "request-promise-core": "1.1.4",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -43750,12 +43569,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
-      "dev": true
-    },
     "stop-iteration-iterator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
@@ -45037,20 +44850,6 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true
-    },
-    "wait-on": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-4.0.0.tgz",
-      "integrity": "sha512-QrW3J8LzS5ADPfD9Rx5S6KJck66xkqyiFKQs9jmUTkIhiEOmkzU7WRZc+MjsnmkrgjitS2xQ4bb13hnlQnKBUQ==",
-      "dev": true,
-      "requires": {
-        "@hapi/joi": "^16.1.8",
-        "lodash": "^4.17.15",
-        "minimist": "^1.2.0",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.8",
-        "rxjs": "^6.5.4"
-      }
     },
     "walkdir": {
       "version": "0.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
         "rxjs": "6.5.5",
         "spectron": "^19.0.0",
         "standard-version": "^9.5.0",
-        "ts-node": "~8.6.2",
         "tslib": "^2.0.0",
         "tslint-config-prettier": "^1.18.0",
         "typescript": "4.8.4",
@@ -24360,38 +24359,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-node": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
-      "dev": true,
-      "dependencies": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-script": "dist/script.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -26580,7 +26547,6 @@
       "dev": true,
       "dependencies": {
         "ajv": "^8.12.0",
-        "ts-node": "^10.9.1",
         "tsx": "^4.7.0",
         "typescript-json-schema": "^0.61.0"
       },
@@ -26595,58 +26561,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.25.1"
-      }
-    },
-    "projects/word-weaver-cli/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "projects/word-weaver-cli/node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
       }
     }
   },
@@ -44550,27 +44464,6 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
-    "ts-node": {
-      "version": "8.6.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.6",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        }
-      }
-    },
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
@@ -45850,7 +45743,6 @@
       "requires": {
         "@types/node": "^20.8.6",
         "ajv": "^8.12.0",
-        "ts-node": "^10.9.1",
         "tsx": "^4.7.0",
         "typescript-json-schema": "^0.61.0"
       },
@@ -45862,33 +45754,6 @@
           "dev": true,
           "requires": {
             "undici-types": "~5.25.1"
-          }
-        },
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        },
-        "ts-node": {
-          "version": "10.9.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-          "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-          "dev": true,
-          "requires": {
-            "@cspotcode/source-map-support": "^0.8.0",
-            "@tsconfig/node10": "^1.0.7",
-            "@tsconfig/node12": "^1.0.7",
-            "@tsconfig/node14": "^1.0.0",
-            "@tsconfig/node16": "^1.0.2",
-            "acorn": "^8.4.1",
-            "acorn-walk": "^8.1.1",
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "v8-compile-cache-lib": "^3.0.1",
-            "yn": "3.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "typescript": "4.8.4",
     "uuid": "^3.4.0",
     "v8-to-istanbul": "^9.1.3",
-    "wait-on": "4.0.0",
     "webdriver-manager": "12.1.7",
     "webpack-bundle-analyzer": "^4.9.0",
     "word-weaver-cli": "file:projects/word-weaver-cli",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "rxjs": "6.5.5",
     "spectron": "^19.0.0",
     "standard-version": "^9.5.0",
-    "ts-node": "~8.6.2",
     "tslib": "^2.0.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "4.8.4",

--- a/projects/word-weaver-cli/notes.txt
+++ b/projects/word-weaver-cli/notes.txt
@@ -1,5 +1,5 @@
 npm install ajv
-npm install ts-node
+npm install tsx
 npm install typescript-json-schema
 
 cp ../word-weaver/src/config/schema.ts .
@@ -8,4 +8,4 @@ for type in Options Verbs Pronouns Conjugations; do
     npx typescript-json-schema --ignoreErrors package.json $type > $type.jsonschema.json
 done
 
-npx ts-node validate.ts
+npx tsx validate.ts

--- a/projects/word-weaver-cli/package.json
+++ b/projects/word-weaver-cli/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "ajv": "^8.12.0",
-    "ts-node": "^10.9.1",
     "tsx": "^4.7.0",
     "typescript-json-schema": "^0.61.0"
   },

--- a/projects/word-weaver-cli/tsconfig.json
+++ b/projects/word-weaver-cli/tsconfig.json
@@ -12,8 +12,5 @@
     "module": "esnext",
     "target": "es2020",
     "lib": ["esnext", "dom"]
-  },
-  "ts-node": {
-    "esm": true
   }
 }


### PR DESCRIPTION
Just tidying up after last night's quick patch.