### PR TITLE
Fixing slow speed/long wait for initial conjugation with no cache

### DIFF
--- a/projects/word-weaver/src/app/app/app.component.ts
+++ b/projects/word-weaver/src/app/app/app.component.ts
@@ -60,9 +60,7 @@ export class AppComponent implements OnInit {
     private pronounService: PronounService,
     private optionService: OptionService,
     private conjugationService: ConjugationService
-  ) {
-    this.verbService.verbs;
-  }
+  ) {}
 
   private static isIEorEdgeOrSafari() {
     return ["ie", "edge", "safari"].includes(browser().name);
@@ -86,6 +84,7 @@ export class AppComponent implements OnInit {
 
   loadAssets() {
     new Promise<void>((resolve, reject) => {
+      this.verbService.verbs;
       this.pronounService.pronouns;
       this.optionService.options;
       if (this.conjugationService.conjugations) {

--- a/projects/word-weaver/src/app/app/app.component.ts
+++ b/projects/word-weaver/src/app/app/app.component.ts
@@ -18,6 +18,13 @@ import {
   actionSettingsChangeLanguage,
 } from "../core/settings/settings.actions";
 
+import {
+  VerbService,
+  OptionService,
+  PronounService,
+  ConjugationService,
+} from "../core/core.module";
+
 @Component({
   selector: "ww-root",
   templateUrl: "./app.component.html",
@@ -48,8 +55,14 @@ export class AppComponent implements OnInit {
   theme$: Observable<string>;
   constructor(
     private store: Store,
-    private storageService: LocalStorageService
-  ) {}
+    private storageService: LocalStorageService,
+    private verbService: VerbService,
+    private pronounService: PronounService,
+    private optionService: OptionService,
+    private conjugationService: ConjugationService
+  ) {
+    this.verbService.verbs;
+  }
 
   private static isIEorEdgeOrSafari() {
     return ["ie", "edge", "safari"].includes(browser().name);
@@ -68,6 +81,21 @@ export class AppComponent implements OnInit {
     this.stickyHeader$ = this.store.pipe(select(selectSettingsStickyHeader));
     this.language$ = this.store.pipe(select(selectSettingsLanguage));
     this.theme$ = this.store.pipe(select(selectEffectiveTheme));
+    this.loadAssets();
+  }
+
+  loadAssets() {
+    new Promise<void>((resolve, reject) => {
+      this.pronounService.pronouns;
+      this.optionService.options;
+      if (this.conjugationService.conjugations) {
+        console.log("conjugationService.conjugations");
+        resolve();
+      } else {
+        console.log("conjugationService.conjugations not loaded");
+        reject("conjugationService.conjugations not loaded");
+      }
+    });
   }
 
   onLanguageSelect({ value: language }) {

--- a/projects/word-weaver/src/app/app/app.component.ts
+++ b/projects/word-weaver/src/app/app/app.component.ts
@@ -84,15 +84,17 @@ export class AppComponent implements OnInit {
 
   loadAssets() {
     new Promise<void>((resolve, reject) => {
-      this.verbService.verbs;
-      this.pronounService.pronouns;
-      this.optionService.options;
-      if (this.conjugationService.conjugations) {
-        console.log("conjugationService.conjugations");
+      if (
+        this.conjugationService.conjugations &&
+        this.verbService.verbs &&
+        this.optionService.options &&
+        this.pronounService.pronouns
+      ) {
+        console.log("All assets loaded");
         resolve();
       } else {
-        console.log("conjugationService.conjugations not loaded");
-        reject("conjugationService.conjugations not loaded");
+        console.log("Not all assets loaded");
+        reject("Not all assets loaded");
       }
     });
   }

--- a/projects/word-weaver/src/app/core/conjugation/conjugation.service.ts
+++ b/projects/word-weaver/src/app/core/conjugation/conjugation.service.ts
@@ -22,7 +22,7 @@ import { environment } from "../../../environments/environment";
   providedIn: "root",
 })
 export class ConjugationService {
-  conjugations;
+  conjugations: Conjugations;
   conjugations$: Observable<Conjugations>;
   random$: Observable<ConjugationObject>;
   path = environment.usePrecompressedData
@@ -37,6 +37,10 @@ export class ConjugationService {
       ),
       shareReplay(1)
     );
+    this.conjugations$.subscribe(
+      (conjugations) => (this.conjugations = conjugations)
+    );
+
     this.random$ = this.conjugations$.pipe(
       map((res) => this.getRandomOption(res))
     );


### PR DESCRIPTION
# Description

At slower internet speeds and larger data files, the initial conjugation before caching has happened can take a long time, ranging anywhere from approximately 30 seconds to a few minutes, depending on the connection. 

The solution is in two parts:

1. Introducing a `subscribe` in the conjugation service.
2. Accessing all data in a promise in the app component.

I am not totally sure why point 1 seems to speed things up so drastically, and I'm not sure if the app component is _the_ place for an initial load, so I am **open for revisions and suggestions** for a less hacky solution.

Also it's failing tests, which further confirms my "hacky" suspicions. 

# Example Demos

## Current state of initial conjugation - throttled 38.8 mbps dl, 9.52 mbps ul, 9s latency (Akwiratékha's internet speed) - approx 2min40sec 
https://github.com/user-attachments/assets/0c69c604-3650-43dc-884d-086ba39a4210

## Initial conjugation of updated solution - throttled 38.8 mbps dl, 9.52 mbps ul, 9s latency - basically instantaneous
https://github.com/user-attachments/assets/6e8faa76-26a2-4ab4-a695-162382d2b76e

[Click here](https://leafy-lollipop-b26e60.netlify.app/) to see netlify demo of solution


## Realistic user experience of conjugation throttled on 4g "slow" internet
On a slower internet speed with someone doing a small amount of searching/deciding, they might expect approx 5 seconds of extra load time for their conjugation. 

https://github.com/user-attachments/assets/6c17811c-c1da-4279-9707-6da380829221

