### PR TITLE
feat: add UI changing of speaker

### DIFF
--- a/e2e-tests/e2e.spec.ts
+++ b/e2e-tests/e2e.spec.ts
@@ -15,14 +15,13 @@ test("navigate to tableviewer", async ({ page }) => {
   await expect(page.url()).toContain("tableviewer");
 });
 
-// TODO: For some reason this is broken in CI.
-// test("get started link", async ({ page }) => {
-//   await page.goto(HOME + "/wordmaker");
+test("get started link", async ({ page }) => {
+  await page.goto(HOME + "/wordmaker");
 
-//   await expect(page.url()).toContain("wordmaker");
+  await expect(page.url()).toContain("wordmaker");
 
-//   // Click the get started link.
-//   await page.getByTestId("start").click();
+  // Click the get started link.
+  await page.getByTestId("start").click();
 
-//   await expect(page.url()).toContain("stepper");
-// });
+  await expect(page.url()).toContain("stepper");
+});

--- a/projects/every-voice/src/lib/every-voice.service.spec.ts
+++ b/projects/every-voice/src/lib/every-voice.service.spec.ts
@@ -16,7 +16,7 @@ describe("EveryVoiceService", () => {
       imports: [
         EveryVoiceModule.forRoot({
           apiUrl: "test",
-          enableTTS: true,
+          enableTTS: false,
           requiresAuth: false,
           clientId: "",
           audience: "",

--- a/projects/word-weaver/src/app/core/settings/settings.actions.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.actions.ts
@@ -65,6 +65,17 @@ export const actionSettingsChangeAnimationsElements = createAction(
   "[Settings] Change Animations Elements",
   props<{ elementsAnimations: boolean }>()
 );
+
+export const actionSettingsChangeTtsDiffusionSteps = createAction(
+  "[Settings] Change TTS Settings",
+  props<{ diffusionSteps: number }>()
+);
+
+export const actionSettingsChangeTtsSpeaker = createAction(
+  "[Settings] Change TTS Speaker",
+  props<{ speaker: string }>()
+);
+
 export const actionSettingsChangeHour = createAction(
   "[Settings] Change Hours",
   props<{ hour: number }>()

--- a/projects/word-weaver/src/app/core/settings/settings.effects.spec.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.effects.spec.ts
@@ -16,6 +16,7 @@ import {
 import { SettingsEffects, SETTINGS_KEY } from "./settings.effects";
 import { SettingsState, NIGHT_MODE_THEME } from "./settings.model";
 import { actionSettingsChangeTheme } from "./settings.actions";
+import { EveryVoiceService } from "@everyvoice/every-voice";
 
 const scheduler = new TestScheduler((actual, expected) => {
   // @ts-ignore
@@ -29,6 +30,7 @@ describe("SettingsEffects", () => {
   let animationsService: jasmine.SpyObj<AnimationsService>;
   let translateService: jasmine.SpyObj<TranslateService>;
   let notificationService: jasmine.SpyObj<NotificationService>;
+  let tts: jasmine.SpyObj<EveryVoiceService>;
   let store: jasmine.SpyObj<Store<AppState>>;
 
   beforeEach(() => {
@@ -52,6 +54,7 @@ describe("SettingsEffects", () => {
     ]);
     translateService = jasmine.createSpyObj("TranslateService", ["use"]);
     notificationService = jasmine.createSpyObj("NotificationService", ["use"]);
+    tts = jasmine.createSpyObj("EveryVoiceService", ["use"]);
     store = jasmine.createSpyObj("store", ["pipe"]);
   });
 
@@ -92,7 +95,8 @@ describe("SettingsEffects", () => {
         localStorageService,
         animationsService,
         translateService,
-        notificationService
+        notificationService,
+        tts
       );
 
       effect.persistSettings.subscribe(() => {

--- a/projects/word-weaver/src/app/core/settings/settings.effects.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.effects.ts
@@ -30,6 +30,8 @@ import {
   actionSettingsChangeStickyHeader,
   actionSettingsChangeTestApi,
   actionSettingsChangeTheme,
+  actionSettingsChangeTtsDiffusionSteps,
+  actionSettingsChangeTtsSpeaker,
 } from "./settings.actions";
 import { State } from "./settings.model";
 import {
@@ -38,8 +40,10 @@ import {
   selectPageAnimations,
   selectSettingsAnalytics,
   selectSettingsLanguage,
+  selectTtsSpeaker,
 } from "./settings.selectors";
 import { NotificationService } from "../core.module";
+import { EveryVoiceService } from "@everyvoice/every-voice";
 
 export const SETTINGS_KEY = "SETTINGS";
 
@@ -56,8 +60,21 @@ export class SettingsEffects {
     private localStorageService: LocalStorageService,
     private animationsService: AnimationsService,
     private translateService: TranslateService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private tts: EveryVoiceService
   ) {}
+
+  changeTtsSpeaker = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(actionSettingsChangeTtsSpeaker),
+        withLatestFrom(this.store.pipe(select(selectTtsSpeaker))),
+        tap(([action, speaker]) => {
+          this.tts.speakerID = speaker;
+        })
+      ),
+    { dispatch: false }
+  );
 
   changeHour = createEffect(() =>
     merge(
@@ -116,7 +133,9 @@ export class SettingsEffects {
           actionSettingsChangeTestApi,
           actionSettingsChangeLevel,
           actionSettingsChangeHighlight,
-          actionSettingsChangeTheme
+          actionSettingsChangeTheme,
+          actionSettingsChangeTtsDiffusionSteps,
+          actionSettingsChangeTtsSpeaker
         ),
         withLatestFrom(this.store.pipe(select(selectSettingsState))),
         tap(([action, settings]) =>

--- a/projects/word-weaver/src/app/core/settings/settings.model.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.model.ts
@@ -27,6 +27,10 @@ export interface SettingsState {
     primary: string;
     accent: string;
   };
+  ttsSettings?: {
+    diffusionSteps?: number;
+    speaker?: string;
+  };
 }
 
 export interface State extends AppState {

--- a/projects/word-weaver/src/app/core/settings/settings.reducer.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.reducer.ts
@@ -16,6 +16,8 @@ import {
   actionSettingsChangeTestApi,
   actionSettingsChangeTheme,
   actionSettingsChangeThemeColors,
+  actionSettingsChangeTtsDiffusionSteps,
+  actionSettingsChangeTtsSpeaker,
 } from "./settings.actions";
 import { NIGHT_MODE_THEME, SettingsState } from "./settings.model";
 
@@ -38,6 +40,10 @@ const initialBaseState: SettingsState = {
   level: environment.config.level,
   highlight: environment.config.highlight,
   hour: new Date().getHours(),
+  ttsSettings: {
+    diffusionSteps: environment.ttsConfig.diffusionSteps,
+    speaker: environment.ttsConfig.speakerID,
+  },
 };
 
 export const initialState: SettingsState = {
@@ -73,6 +79,20 @@ const reducer = createReducer(
     colors: {
       ...state.colors,
       ...{ primary: action.primary, accent: action.accent },
+    },
+  })),
+  on(actionSettingsChangeTtsDiffusionSteps, (state, action) => ({
+    ...state,
+    ttsSettings: {
+      ...state.ttsSettings,
+      ...{ diffusionSteps: action.diffusionSteps },
+    },
+  })),
+  on(actionSettingsChangeTtsSpeaker, (state, action) => ({
+    ...state,
+    ttsSettings: {
+      ...state.ttsSettings,
+      ...{ speaker: action.speaker },
     },
   })),
   on(actionSettingsChangeHighlight, (state, action) => {

--- a/projects/word-weaver/src/app/core/settings/settings.selectors.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.selectors.ts
@@ -62,6 +62,16 @@ export const selectHour = createSelector(
   (settings) => settings.hour
 );
 
+export const selectTtsSettings = createSelector(
+  selectSettings,
+  (settings) => settings.ttsSettings
+);
+
+export const selectTtsSpeaker = createSelector(
+  selectSettings,
+  (settings) => settings.ttsSettings.speaker
+);
+
 export const selectIsNightHour = createSelector(
   selectAutoNightMode,
   selectHour,

--- a/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.html
+++ b/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.html
@@ -67,6 +67,29 @@
             </mat-select>
           </mat-form-field>
         </div>
+        <div
+          class="icon-form-field"
+          *ngIf="tts.ttsEnabledAndAuthenticated$ | async"
+        >
+          <mat-icon color="accent"> record_voice_over </mat-icon>
+          <mat-form-field class="control">
+            <mat-select
+              [placeholder]="
+                'ww.pages.settings.general.ttsPlaceholder' | translate
+              "
+              [ngModel]="settings.ttsSettings.speaker"
+              (selectionChange)="onTtsSpeakerChange($event)"
+              name="speaker"
+            >
+              <mat-option
+                *ngFor="let s of this.tts.speakers$ | async"
+                [value]="s"
+              >
+                {{ s }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
         <div class="icon-form-field">
           <mat-icon color="accent">
             <fa-icon icon="bars" color="accent"></fa-icon>

--- a/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.ts
+++ b/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.ts
@@ -21,10 +21,12 @@ import {
   actionSettingsChangeStickyHeader,
   actionSettingsChangeTestApi,
   actionSettingsChangeTheme,
+  actionSettingsChangeTtsSpeaker,
 } from "../../../core/settings/settings.actions";
 import { SettingsState, State } from "../../../core/settings/settings.model";
 import { selectSettings } from "../../../core/settings/settings.selectors";
 import { environment } from "../../../../environments/environment";
+import { EveryVoiceService } from "@everyvoice/every-voice";
 
 @Component({
   selector: "ww-settings",
@@ -74,11 +76,10 @@ export class SettingsContainerComponent implements OnDestroy, OnInit {
   }));
   showInstall = false;
   unsubscribe$ = new Subject<void>();
-  constructor(private store: Store<State>) {}
+  constructor(private store: Store<State>, public tts: EveryVoiceService) {}
 
   ngOnInit() {
     this.settings$ = this.store.pipe(select(selectSettings));
-    this.settings$.subscribe((settings) => console.log(settings));
     // this.deferredPrompt$ = fromEvent(window, "beforeinstallprompt").pipe(
     //   takeUntil(this.unsubscribe$),
     //   map(e => {
@@ -116,6 +117,10 @@ export class SettingsContainerComponent implements OnDestroy, OnInit {
 
   onAutoNightModeToggle({ checked: autoNightMode }) {
     this.store.dispatch(actionSettingsChangeAutoNightMode({ autoNightMode }));
+  }
+
+  onTtsSpeakerChange({ value: speaker }) {
+    this.store.dispatch(actionSettingsChangeTtsSpeaker({ speaker }));
   }
 
   onStickyHeaderToggle({ checked: stickyHeader }) {

--- a/projects/word-weaver/src/assets/i18n/en.json
+++ b/projects/word-weaver/src/assets/i18n/en.json
@@ -64,7 +64,8 @@
             "title": "Display Tiers",
             "translation": "Translation"
           },
-          "title": "General"
+          "title": "General",
+          "ttsPlaceholder": "TTS Voice"
         },
         "night-mode": "Auto night mode (from 21:00 to 7:00)",
         "notifications": {

--- a/projects/word-weaver/src/assets/i18n/fr.json
+++ b/projects/word-weaver/src/assets/i18n/fr.json
@@ -1,5 +1,4 @@
 {
-  "": null,
   "ww": {
     "common": {
       "language": "Dans la langue du conjugueur",
@@ -65,7 +64,8 @@
             "title": "Couches à afficher",
             "translation": "Traduction"
           },
-          "title": "Paramètres généraux"
+          "title": "Paramètres généraux",
+          "ttsPlaceholder": "Voix"
         },
         "night-mode": "Mode jour/nuit automatique (de 21 h à 7 h)",
         "notifications": {


### PR DESCRIPTION
I'm just putting the steps involved in this PR to document the steps needed to adjust state. To summarize, the steps are:

1. define an action which just changes the value of the setting (projects/word-weaver/src/app/core/settings/settings.actions.ts)
2. add the setting along with defaults to the model ( projects/word-weaver/src/app/core/settings/settings.model.ts )
3. define how the action changes the state (projects/word-weaver/src/app/core/settings/settings.reducer.ts)
4. define some selectors to only take the slice of the state you need (projects/word-weaver/src/app/core/settings/settings.selectors.ts)
5. Then you can define any number of side-effects that trigger from a given action. In my case, whenever the speaker changes, we store it in localstorage for persistent state across sessions, and also copy the variable to the EveryVoiceService so that it is included in future calls to the API (projects/word-weaver/src/app/core/settings/settings.effects.ts)
6. The rest is adding the UI view (projects/word-weaver/src/app/pages/settings/settings/settings-container.component.html) and logic (projects/word-weaver/src/app/pages/settings/settings/settings-container.component.ts)

It looks like a lot of boiler plate, but it keeps everything nice and tidy so that we can easily separate which parts of the state should be persisted, or trigger side-effects.