### PR TITLE
feat: require email to be verified before logging in

### DIFF
--- a/projects/word-weaver/src/app/app-routing.module.ts
+++ b/projects/word-weaver/src/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from "@angular/core";
 import { PreloadAllModules, RouterModule, Routes } from "@angular/router";
 import { AuthGuard } from "@auth0/auth0-angular";
 import { UserProfileComponent } from "./shared/profile/profile.component";
+import { AuthCallbackComponent } from "./shared/auth/auth-callback.component";
 
 const routes: Routes = [
   {
@@ -37,6 +38,10 @@ const routes: Routes = [
       import("./pages/tableviewer/tableviewer.module").then(
         (m) => m.TableviewerModule
       ),
+  },
+  {
+    path: "auth-callback", // Handle Auth0 redirect with errors here
+    component: AuthCallbackComponent,
   },
   {
     path: "**",

--- a/projects/word-weaver/src/app/core/core.module.ts
+++ b/projects/word-weaver/src/app/core/core.module.ts
@@ -207,9 +207,10 @@ export const httpLoaderFactory = (http: HttpClient) =>
       clientId: environment.ttsConfig.clientId,
       authorizationParams: {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        redirect_uri: window.location.origin,
+        redirect_uri: `${window.location.origin}/auth-callback`,
         audience: environment.ttsConfig.audience,
       },
+      skipRedirectCallback: true,
     }),
   ],
   exports: [

--- a/projects/word-weaver/src/app/core/notifications/notification.service.ts
+++ b/projects/word-weaver/src/app/core/notifications/notification.service.ts
@@ -75,7 +75,7 @@ export class NotificationService {
       ...this.config,
       ...{
         panelClass: "error-notification-overlay",
-        duration: 3000,
+        duration: 15000,
         verticalPosition: "bottom",
       },
     };

--- a/projects/word-weaver/src/app/shared/auth/auth-callback.component.ts
+++ b/projects/word-weaver/src/app/shared/auth/auth-callback.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { AuthService } from "@auth0/auth0-angular";
+import { NotificationService } from "../../core/core.module";
+import { TranslateService } from "@ngx-translate/core";
+import { catchError, switchMap, takeUntil, tap } from "rxjs/operators";
+import { of, Subject } from "rxjs";
+
+@Component({
+  selector: "ww-app-auth-callback",
+  template: `<p>Processing login...</p>`,
+})
+export class AuthCallbackComponent implements OnInit, OnDestroy {
+  unsubscribe$ = new Subject();
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private auth: AuthService,
+    private notificationService: NotificationService,
+    private translate: TranslateService
+  ) {}
+
+  ngOnDestroy(): void {
+    this.unsubscribe$.next();
+  }
+
+  ngOnInit(): void {
+    this.route.queryParams
+      .pipe(
+        // unsubscribe when we destroy the component
+        takeUntil(this.unsubscribe$),
+        // use the translate service to get an error message from the params otherwise return 'success'
+        switchMap((params) => {
+          const error = params["error"];
+          const errorDescription = params["error_description"];
+
+          if (error && errorDescription) {
+            console.error("Auth0 login error:", error, errorDescription);
+            if (
+              error === "access_denied" &&
+              errorDescription.toLowerCase().includes("verify your email")
+            ) {
+              return this.translate.get(
+                "ww.common.notifications.auth.verification-required"
+              );
+            } else {
+              return this.translate.get(
+                "ww.common.notifications.auth.login-failed"
+              );
+            }
+          }
+          {
+            return of("success");
+          }
+        }),
+        // If the error message is not 'success' use the notifcation service to display the translated error.
+        // and then throw an error
+        tap((message) => {
+          if (message === "success") {
+            return of(null);
+          } else {
+            this.notificationService.error(message);
+            // Stop the pipeline — no redirect handling
+            throw new Error("Auth0 login error intercepted.");
+          }
+        }),
+        // if an error was not thrown, handle the normal authentication redirect back to /profile
+        switchMap(() => this.auth.handleRedirectCallback()),
+        tap(() => this.router.navigate(["/profile"])),
+        // if an error was thrown, send the user back to the main page
+        catchError((err) => {
+          console.error("Redirect callback failed:", err);
+          this.router.navigate(["/"]);
+          return of(null); // End the observable stream gracefully
+        })
+      )
+      .subscribe();
+  }
+}

--- a/projects/word-weaver/src/assets/i18n/en.json
+++ b/projects/word-weaver/src/assets/i18n/en.json
@@ -3,6 +3,10 @@
     "common": {
       "language": "Sample Language",
       "notifications": {
+        "auth": {
+          "login-failed": "Sorry, login failed, please try again.",
+          "verification-required": "Please check your inbox and verify your email address before continuing."
+        },
         "error": {
           "dev": "Hm, something went wrong, please check the console.",
           "general": "Whoops, an error occured."

--- a/projects/word-weaver/src/assets/i18n/fr.json
+++ b/projects/word-weaver/src/assets/i18n/fr.json
@@ -3,6 +3,10 @@
     "common": {
       "language": "Dans la langue du conjugueur",
       "notifications": {
+        "auth": {
+          "login-failed": "Désolé, la connexion a échoué. Veuillez réessayer.",
+          "verification-required": "Veuillez vérifier votre adresse e-mail avant de continuer."
+        },
         "error": {
           "dev": "Désolé, un problème est survenu, prière de vérifier la console.",
           "general": "Oups, une erreur s'est produite."


### PR DESCRIPTION
Marc pointed out an important security issue, that users were still able to log in even if they didn't verify their emails. We want to only allow users to access the site when they have verified their email address. In order to do that, I had to circumvent the default auth0 redirect logic and parse the query parameters of the callback.