### PR TITLE
fix: fixed typo in every-voice service api

### DIFF
--- a/projects/every-voice/src/lib/every-voice.service.ts
+++ b/projects/every-voice/src/lib/every-voice.service.ts
@@ -390,7 +390,7 @@ export class EveryVoiceService {
           console.log(response);
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const blob = new Blob([response.body!], {
-            type: response.headers["content_type"] || "audio/mpeg",
+            type: response.headers["Content-Type"] || "audio/mpeg",
           });
           const url = URL.createObjectURL(blob);
           console.log(blob);


### PR DESCRIPTION
Fixing typo in every-voice service. The 'Content-Type' header was being accessed via 'content_type'. This is a minor bug fix.