### PR TITLE
fix: hide the confusing Test Language Model advanced option

### DIFF
--- a/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.html
+++ b/projects/word-weaver/src/app/pages/settings/settings/settings-container.component.html
@@ -143,8 +143,7 @@
             ></span>
           </div>
         </div>
-
-        <div class="icon-form-field">
+        <div class="icon-form-field" hidden="True">
           <mat-placeholder
             >{{ "ww.pages.settings.advanced" | translate }}
           </mat-placeholder>


### PR DESCRIPTION
cherry picked back from Kawennón:nis