### PR TITLE
fix: off-by-one error in limit only 3-verbs logic

### DIFF
--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.ts
@@ -101,7 +101,7 @@ export class TableviewerVerbPanelComponent implements OnDestroy, OnInit {
   }
 
   selectedRoot(selection: Verb[], root: string) {
-    return selection.map((x) => x.tag).indexOf(root) > 0;
+    return selection.map((x) => x.tag).indexOf(root) >= 0;
   }
 
   getEntriesFrom$(term: string) {


### PR DESCRIPTION
Another bug identified by AI Zone GPT 5.3 codex. Confirmed on `main` with https://wordweavertools.github.io/wordweaver/wordmaker.

<img width="302" height="338" alt="image" src="https://github.com/user-attachments/assets/fc16cba9-30ef-4cdd-b723-c92e498d9823" />

The Run checkbox should not be disabled, it is a off-by-one error in the `selectedRoot` method.