### PR TITLE
State cleanup for fixing #159

### DIFF
--- a/projects/word-weaver/src/app/core/conjugation/conjugation.service.ts
+++ b/projects/word-weaver/src/app/core/conjugation/conjugation.service.ts
@@ -2,7 +2,14 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Store, select } from "@ngrx/store";
 import { Observable, throwError } from "rxjs";
-import { map, shareReplay, switchMap, retry, catchError } from "rxjs/operators";
+import {
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  switchMap,
+  retry,
+  catchError,
+} from "rxjs/operators";
 
 import {
   ConjugationObject,
@@ -12,8 +19,8 @@ import {
   Verb,
 } from "../../../config/config";
 import { GridOrder } from "../../pages/tableviewer/conjugation-grid/conjugation-grid.component";
-import { selectSettingsState } from "../core.state";
-import { SettingsState } from "../settings/settings.model";
+import { AppState } from "../core.state";
+import { selectSettingsBaseUrl } from "../settings/settings.selectors";
 import { TableviewerState } from "../tableviewer-selection/tableviewer-selection.model";
 import { WordmakerState } from "../wordmaker-selection/wordmaker-selection.model";
 import { environment } from "../../../environments/environment";
@@ -29,11 +36,12 @@ export class ConjugationService {
     ? "conjugations.json.gz"
     : "conjugations.json";
   suppressError = true;
-  constructor(private http: HttpClient, private store: Store) {
+  constructor(private http: HttpClient, private store: Store<AppState>) {
     this.conjugations$ = this.store.pipe(
-      select(selectSettingsState),
-      switchMap((settings: SettingsState) =>
-        this.http.get<Conjugations>(settings?.baseUrl + this.path)
+      select(selectSettingsBaseUrl),
+      distinctUntilChanged(),
+      switchMap((baseUrl: string) =>
+        this.http.get<Conjugations>(baseUrl + this.path)
       ),
       retry(2),
       shareReplay(1),

--- a/projects/word-weaver/src/app/core/option/option.service.ts
+++ b/projects/word-weaver/src/app/core/option/option.service.ts
@@ -2,11 +2,18 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Store, select } from "@ngrx/store";
 import { Observable, throwError } from "rxjs";
-import { map, shareReplay, switchMap, retry, catchError } from "rxjs/operators";
+import {
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  switchMap,
+  retry,
+  catchError,
+} from "rxjs/operators";
 
 import { Option } from "../../../config/config";
-import { selectSettingsState } from "../core.state";
-import { SettingsState } from "../settings/settings.model";
+import { AppState } from "../core.state";
+import { selectSettingsBaseUrl } from "../settings/settings.selectors";
 import { environment } from "../../../environments/environment";
 
 @Injectable({
@@ -19,11 +26,12 @@ export class OptionService {
   optionsByType$: Observable<object[]>;
   random$: Observable<Option>;
   suppressError = true;
-  constructor(private http: HttpClient, private store: Store) {
+  constructor(private http: HttpClient, private store: Store<AppState>) {
     this.options$ = this.store.pipe(
-      select(selectSettingsState),
-      switchMap((settings: SettingsState) =>
-        this.http.get<Option[]>(settings?.baseUrl + this.path)
+      select(selectSettingsBaseUrl),
+      distinctUntilChanged(),
+      switchMap((baseUrl: string) =>
+        this.http.get<Option[]>(baseUrl + this.path)
       ),
       retry(2),
       shareReplay(1),

--- a/projects/word-weaver/src/app/core/pronoun/pronoun.service.ts
+++ b/projects/word-weaver/src/app/core/pronoun/pronoun.service.ts
@@ -2,11 +2,18 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Store, select } from "@ngrx/store";
 import { Observable, throwError } from "rxjs";
-import { map, shareReplay, switchMap, retry, catchError } from "rxjs/operators";
+import {
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  switchMap,
+  retry,
+  catchError,
+} from "rxjs/operators";
 
 import { Pronoun } from "../../../config/config";
-import { selectSettingsState } from "../core.state";
-import { SettingsState } from "../settings/settings.model";
+import { AppState } from "../core.state";
+import { selectSettingsBaseUrl } from "../settings/settings.selectors";
 import { environment } from "../../../environments/environment";
 
 @Injectable({
@@ -20,11 +27,12 @@ export class PronounService {
   pronouns$: Observable<Pronoun[]>;
   random$: Observable<Pronoun>;
   suppressError = true;
-  constructor(private http: HttpClient, private store: Store) {
+  constructor(private http: HttpClient, private store: Store<AppState>) {
     this.pronouns$ = this.store.pipe(
-      select(selectSettingsState),
-      switchMap((settings: SettingsState) =>
-        this.http.get<Pronoun[]>(settings?.baseUrl + this.path)
+      select(selectSettingsBaseUrl),
+      distinctUntilChanged(),
+      switchMap((baseUrl: string) =>
+        this.http.get<Pronoun[]>(baseUrl + this.path)
       ),
       retry(2),
       shareReplay(1),
@@ -36,7 +44,7 @@ export class PronounService {
     this.random$ = this.pronouns$.pipe(map((res) => this.getRandomPro(res)));
     this.pronouns$.subscribe((pns) => (this.pronouns = pns));
   }
-  getPronoun(tag) {
+  getPronoun(tag: string) {
     return this.pronouns.filter((p) => p.tag === tag)[0];
   }
 

--- a/projects/word-weaver/src/app/core/settings/settings.effects.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.effects.ts
@@ -5,13 +5,7 @@ import { Actions, createEffect, ofType } from "@ngrx/effects";
 import { select, Store } from "@ngrx/store";
 import { TranslateService } from "@ngx-translate/core";
 import { combineLatest, merge, of, timer } from "rxjs";
-import {
-  distinctUntilChanged,
-  map,
-  mapTo,
-  tap,
-  withLatestFrom,
-} from "rxjs/operators";
+import { distinctUntilChanged, map, tap, withLatestFrom } from "rxjs/operators";
 import { environment } from "../../../environments/environment";
 import { AnimationsService } from "../animations/animations.service";
 import { selectSettingsState } from "../core.state";
@@ -82,16 +76,7 @@ export class SettingsEffects {
       timer(0, 60_000),
       this.actions$.pipe(ofType(actionSettingsChangeAutoNightMode))
     ).pipe(
-      // TODO: the following mapTo() is a bug and should be replaced with:
-      //     map(() => new Date().getHours())
-      //
-      // but doing so would trigger issue #159 at the top of every hour.
-      //
-      // By maintaining this we keep a partial implementation of
-      // day/night theme toggling, without user data loss at every hour.
-      //
-      // Ref: https://github.com/WordWeaverTools/wordweaver/issues/159
-      mapTo(new Date().getHours()),
+      map(() => new Date().getHours()),
       distinctUntilChanged(),
       map((hour) => actionSettingsChangeHour({ hour }))
     )

--- a/projects/word-weaver/src/app/core/settings/settings.effects.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.effects.ts
@@ -40,6 +40,7 @@ import {
   selectPageAnimations,
   selectSettingsAnalytics,
   selectSettingsLanguage,
+  selectTestApi,
   selectTtsSpeaker,
 } from "./settings.selectors";
 import { NotificationService } from "../core.module";
@@ -158,9 +159,9 @@ export class SettingsEffects {
     () =>
       this.actions$.pipe(
         ofType(actionSettingsChangeTestApi),
-        withLatestFrom(this.store.pipe(select(selectSettingsState))),
-        tap(([action, settings]) => {
-          if (settings.testApi) {
+        withLatestFrom(this.store.pipe(select(selectTestApi))),
+        tap(([action, testApi]) => {
+          if (testApi) {
             this.store.dispatch(
               actionSettingsChangeBaseUrl({ baseUrl: this.testBaseUrl })
             );

--- a/projects/word-weaver/src/app/core/settings/settings.model.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.model.ts
@@ -37,3 +37,15 @@ export interface SettingsState {
 export interface State extends AppState {
   settings: SettingsState;
 }
+
+// Narrow, reusable slices of SettingsState for components/templates that
+// only need a couple of fields, not the whole settings object.
+export interface HighlightAndLevel {
+  highlight: Highlight;
+  level: Level;
+}
+
+export interface LevelAndBaseUrl {
+  level: Level;
+  baseUrl: string;
+}

--- a/projects/word-weaver/src/app/core/settings/settings.reducer.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.reducer.ts
@@ -62,9 +62,15 @@ const reducer = createReducer(
     actionSettingsChangeStickyHeader,
     actionSettingsChangeAnimationsPage,
     actionSettingsChangeAnimationsElements,
-    actionSettingsChangeHour,
     actionSettingsChangeBaseUrl,
     (state, action) => ({ ...state, ...action })
+  ),
+  // Guarded separately: the hourly timer re-dispatches this action even
+  // when the hour hasn't changed, and an unconditional spread would hand
+  // out a new SettingsState reference on every tick, cascading into
+  // needless downstream re-fetches for every settings-state consumer.
+  on(actionSettingsChangeHour, (state, action) =>
+    action.hour === state.hour ? state : { ...state, ...action }
   ),
   on(
     actionSettingsChangeAnimationsPageDisabled,

--- a/projects/word-weaver/src/app/core/settings/settings.selectors.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.selectors.ts
@@ -27,6 +27,32 @@ export const selectSettingsBaseUrl = createSelector(
   (state: SettingsState) => state.baseUrl
 );
 
+export const selectSettingsHighlight = createSelector(
+  selectSettings,
+  (state: SettingsState) => state.highlight
+);
+
+export const selectSettingsLevel = createSelector(
+  selectSettings,
+  (state: SettingsState) => state.level
+);
+
+// Combined, narrow selectors for components that only need the
+// tier-display fields (not the whole SettingsState), so unrelated
+// settings changes (theme, hour, language, ...) don't produce a new
+// reference for these and trigger avoidable re-renders/re-fetches.
+export const selectSettingsHighlightAndLevel = createSelector(
+  selectSettingsHighlight,
+  selectSettingsLevel,
+  (highlight, level) => ({ highlight, level })
+);
+
+export const selectSettingsLevelAndBaseUrl = createSelector(
+  selectSettingsLevel,
+  selectSettingsBaseUrl,
+  (level, baseUrl) => ({ level, baseUrl })
+);
+
 export const selectTheme = createSelector(
   selectSettings,
   (settings) => settings.theme

--- a/projects/word-weaver/src/app/core/settings/settings.selectors.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.selectors.ts
@@ -22,6 +22,11 @@ export const selectSettingsLanguage = createSelector(
   (state: SettingsState) => state.language
 );
 
+export const selectSettingsBaseUrl = createSelector(
+  selectSettings,
+  (state: SettingsState) => state.baseUrl
+);
+
 export const selectTheme = createSelector(
   selectSettings,
   (settings) => settings.theme

--- a/projects/word-weaver/src/app/core/tableviewer-selection/tableviewer-selection.effects.ts
+++ b/projects/word-weaver/src/app/core/tableviewer-selection/tableviewer-selection.effects.ts
@@ -1,17 +1,11 @@
 import { Injectable } from "@angular/core";
 import { marker } from "@colsen1991/ngx-translate-extract-marker";
 import { Actions, createEffect, ofType } from "@ngrx/effects";
-import { select, Store } from "@ngrx/store";
+import { Store } from "@ngrx/store";
 import { EMPTY } from "rxjs";
-import {
-  concatMap,
-  map,
-  switchMap,
-  take,
-  withLatestFrom,
-} from "rxjs/operators";
+import { concatMap, map, switchMap, withLatestFrom } from "rxjs/operators";
 import { ConjugationService } from "../../core/conjugation/conjugation.service";
-import { selectSettingsState, selectTableviewerState } from "../core.state";
+import { selectTableviewerState } from "../core.state";
 // import { LocalStorageService } from "../local-storage/local-storage.service";
 import { NotificationService } from "../notifications/notification.service";
 import {
@@ -88,21 +82,14 @@ export class TableviewerEffects {
 
         this.store.dispatch(actionChangeLoading({ loading: true }));
 
-        return this.store.pipe(
-          select(selectSettingsState),
-          take(1),
-          switchMap((settings) => {
-            console.log("conjugated");
-            return this.conjugationService.conjugations$.pipe(
-              map((data) =>
-                this.conjugationService.filterConjugations(data, selection)
-              ),
-              map((filtered) => [
-                actionChangeLoading({ loading: false }),
-                actionChangeConjugations({ conjugations: filtered }),
-              ])
-            );
-          }),
+        return this.conjugationService.conjugations$.pipe(
+          map((data) =>
+            this.conjugationService.filterConjugations(data, selection)
+          ),
+          map((filtered) => [
+            actionChangeLoading({ loading: false }),
+            actionChangeConjugations({ conjugations: filtered }),
+          ]),
           concatMap((actions) => actions) // emit actions one by one
         );
       })

--- a/projects/word-weaver/src/app/core/tableviewer-selection/tableviewer-selection.reducer.ts
+++ b/projects/word-weaver/src/app/core/tableviewer-selection/tableviewer-selection.reducer.ts
@@ -1,5 +1,6 @@
 import { Action, createReducer, on } from "@ngrx/store";
 import { initialTableViewerSettings } from "../../../config/config";
+import { sameTagged } from "../../shared/utils/tagged-array.util";
 import {
   actionChangeAgents,
   actionChangeConjugations,
@@ -41,10 +42,6 @@ const reducer = createReducer(
   initialState,
   // Basic updates
   on(
-    actionChangeAgents,
-    actionChangeOptions,
-    actionChangePatients,
-    actionChangeVerbs,
     actionChangeTreeViewDepth,
     actionChangeConjugations,
     actionChangeLoading,
@@ -52,6 +49,22 @@ const reducer = createReducer(
     actionChangeVerbSearchTerm,
     // actionChangeGridOrder,
     (state, action) => ({ ...state, ...action })
+  ),
+  // Tagged-array selections: guarded so a spurious re-dispatch with a
+  // semantically identical selection (e.g. from a rebuilt checkbox group)
+  // doesn't hand out a new state reference and cascade into unnecessary
+  // re-renders/re-fetches downstream.
+  on(actionChangeVerbs, (state, { root }) =>
+    sameTagged(state.root, root) ? state : { ...state, root }
+  ),
+  on(actionChangeAgents, (state, { agent }) =>
+    sameTagged(state.agent, agent) ? state : { ...state, agent }
+  ),
+  on(actionChangePatients, (state, { patient }) =>
+    sameTagged(state.patient, patient) ? state : { ...state, patient }
+  ),
+  on(actionChangeOptions, (state, { option }) =>
+    sameTagged(state.option, option) ? state : { ...state, option }
   ),
   // Toggles
   on(actionToggleTreeViewOrder, (state, action) => {

--- a/projects/word-weaver/src/app/core/verb/verb.service.ts
+++ b/projects/word-weaver/src/app/core/verb/verb.service.ts
@@ -2,11 +2,18 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Store, select } from "@ngrx/store";
 import { Observable, throwError } from "rxjs";
-import { map, shareReplay, switchMap, retry, catchError } from "rxjs/operators";
+import {
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  switchMap,
+  retry,
+  catchError,
+} from "rxjs/operators";
 
 import { Verb } from "../../../config/config";
-import { selectSettingsState } from "../core.state";
-import { SettingsState } from "../settings/settings.model";
+import { AppState } from "../core.state";
+import { selectSettingsBaseUrl } from "../settings/settings.selectors";
 import { environment } from "../../../environments/environment";
 
 @Injectable({
@@ -18,11 +25,12 @@ export class VerbService {
   verbs$: Observable<Verb[]>;
   random$: Observable<Verb>;
   suppressError = true;
-  constructor(private http: HttpClient, private store: Store) {
+  constructor(private http: HttpClient, private store: Store<AppState>) {
     this.verbs$ = this.store.pipe(
-      select(selectSettingsState),
-      switchMap((settings: SettingsState) =>
-        this.http.get<Verb[]>(settings?.baseUrl + this.path)
+      select(selectSettingsBaseUrl),
+      distinctUntilChanged(),
+      switchMap((baseUrl: string) =>
+        this.http.get<Verb[]>(baseUrl + this.path)
       ),
       retry(2),
       shareReplay(1),

--- a/projects/word-weaver/src/app/pages/tableviewer/conjugation-grid/conjugation-grid.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/conjugation-grid/conjugation-grid.component.ts
@@ -21,8 +21,11 @@ import {
   PronounService,
   VerbService,
 } from "../../../core/core.module";
-import { SettingsState, State } from "../../../core/settings/settings.model";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import {
+  HighlightAndLevel,
+  State,
+} from "../../../core/settings/settings.model";
+import { selectSettingsHighlightAndLevel } from "../../../core/settings/settings.selectors";
 import { selectTableviewerGridSlice } from "../../../core/tableviewer-selection/tableviewer-selection.selectors";
 
 export type GridOrderOptions = "root" | "pn" | "option";
@@ -47,7 +50,7 @@ export class ConjugationGridComponent
   keys = Object.keys;
   displayTier = TIERS[0];
   tiers$: Observable<Tier[]>;
-  settings$: Observable<SettingsState>;
+  settings$: Observable<HighlightAndLevel>;
   dataSources: MatTableDataSource<Conjugations>[];
   uniqueCol: string[];
   uniqueMain: string[];
@@ -66,7 +69,7 @@ export class ConjugationGridComponent
   ngOnInit(): void {
     this.settings$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectSettings)
+      select(selectSettingsHighlightAndLevel)
     );
     this.tiers$ = this.settings$.pipe(
       takeUntil(this.unsubscribe$),

--- a/projects/word-weaver/src/app/pages/tableviewer/conjugation-list/conjugation-list.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/conjugation-list/conjugation-list.component.ts
@@ -9,8 +9,11 @@ import { select, Store } from "@ngrx/store";
 import { Observable, Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { Conjugations, TIERS } from "../../../../config/config";
-import { SettingsState, State } from "../../../core/settings/settings.model";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import {
+  HighlightAndLevel,
+  State,
+} from "../../../core/settings/settings.model";
+import { selectSettingsHighlightAndLevel } from "../../../core/settings/settings.selectors";
 
 @Component({
   selector: "ww-conjugation-list",
@@ -21,7 +24,7 @@ import { selectSettings } from "../../../core/settings/settings.selectors";
 export class ConjugationListComponent implements OnDestroy, OnInit {
   @Input() data$: Observable<Conjugations>;
 
-  settings$: Observable<SettingsState>;
+  settings$: Observable<HighlightAndLevel>;
   tiers = TIERS;
   // selection$: Observable<TableviewerState>;
   unsubscribe$ = new Subject<void>();
@@ -30,7 +33,7 @@ export class ConjugationListComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.settings$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectSettings)
+      select(selectSettingsHighlightAndLevel)
     );
   }
 

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.html
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.html
@@ -1,4 +1,4 @@
-<div class="panel" *ngIf="settings$ | async as settings">
+<div class="panel">
   <div class="panel__header__container">
     <div *ngIf="showToolbar" class="panel__header panel__header--tableview">
       <h5 #header class="panel__title">

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.ts
@@ -22,8 +22,7 @@ import {
   ROUTE_ANIMATIONS_ELEMENTS,
 } from "../../../core/core.module";
 import { actionSettingsChangeThemeColors } from "../../../core/settings/settings.actions";
-import { SettingsState, State } from "../../../core/settings/settings.model";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import { State } from "../../../core/settings/settings.model";
 import {
   actionChangeGridOrder,
   actionChangeTreeViewDepth,
@@ -64,7 +63,6 @@ export class TableviewerConjPanelComponent
   @ViewChild("header") header;
   @ViewChild("conjugate") conjugateBtn;
   // Basic config
-  settings$: Observable<SettingsState>;
   selection$: Observable<TableviewerState>;
   gridDataState$: Observable<Partial<TableviewerState>>;
   listDataState$: Observable<Partial<TableviewerState>>;
@@ -99,10 +97,6 @@ export class TableviewerConjPanelComponent
 
   ngOnInit(): void {
     // populate with store's selection
-    this.settings$ = this.store.pipe(
-      takeUntil(this.unsubscribe$),
-      select(selectSettings)
-    );
     this.selection$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
       select(selectTableviewer)

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-verb-panel/tableviewer-verb-panel.component.ts
@@ -43,18 +43,30 @@ export class TableviewerVerbPanelComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.searchField = new FormControl();
     this.verbForm = this.fb.group({ search: this.searchField });
+    let checkboxValueChangesSubscribed = false;
     // Get Verbs
     this.verbs$
       .pipe(
         takeUntil(this.unsubscribe$),
-        // Create checkbox group
+        // Create checkbox group, skipping verbs that already have a
+        // control so a re-emission of verbs$ doesn't reset the user's
+        // existing selection back to unchecked.
         tap((verbs) =>
-          verbs.map((verb) =>
-            this.checkboxGroup.addControl(verb["tag"], new FormControl(false))
-          )
+          verbs.forEach((verb) => {
+            if (!this.checkboxGroup.contains(verb["tag"])) {
+              this.checkboxGroup.addControl(
+                verb["tag"],
+                new FormControl(false)
+              );
+            }
+          })
         ),
-        // Subscribe to checkbox valuechanges
-        tap((x) =>
+        // Subscribe to checkbox valuechanges exactly once
+        tap(() => {
+          if (checkboxValueChangesSubscribed) {
+            return;
+          }
+          checkboxValueChangesSubscribed = true;
           this.checkboxGroup.valueChanges
             .pipe(
               takeUntil(this.unsubscribe$),
@@ -69,10 +81,10 @@ export class TableviewerVerbPanelComponent implements OnDestroy, OnInit {
               // Dispatch action to store
               tap((selectedVerbs) => this.onVerbSelect(selectedVerbs))
             )
-            .subscribe()
-        )
+            .subscribe();
+        })
       )
-      .subscribe((x) => {
+      .subscribe(() => {
         // change viewable verbs
         this.viewableVerbs$ = this.searchField.valueChanges.pipe(
           takeUntil(this.unsubscribe$),
@@ -80,10 +92,22 @@ export class TableviewerVerbPanelComponent implements OnDestroy, OnInit {
           switchMap((term) => this.getEntriesFrom$(term))
         );
       });
-    // populate with store's selection
+    // populate with store's selection, and reconcile the checkbox group
+    // with the store so external changes (the 3-item cap, deselecting a
+    // chip, deep links) stay in sync without re-dispatching to the store.
     this.selection$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectTableViewerRoot)
+      select(selectTableViewerRoot),
+      tap((selection) => {
+        const selectedTags = new Set(selection.map((verb) => verb["tag"]));
+        Object.keys(this.checkboxGroup.controls).forEach((tag) => {
+          const control = this.checkboxGroup.controls[tag];
+          const shouldBeChecked = selectedTags.has(tag);
+          if (control.value !== shouldBeChecked) {
+            control.setValue(shouldBeChecked, { emitEvent: false });
+          }
+        });
+      })
     );
   }
 

--- a/projects/word-weaver/src/app/pages/wordmaker/wordmaker-conj-step/wordmaker-conj-step.component.ts
+++ b/projects/word-weaver/src/app/pages/wordmaker/wordmaker-conj-step/wordmaker-conj-step.component.ts
@@ -8,9 +8,12 @@ import { Observable, Subject } from "rxjs";
 import { switchMap, map, takeUntil } from "rxjs/operators";
 import { WordmakerState } from "../../../core/wordmaker-selection/wordmaker-selection.model";
 import { selectWordmaker } from "../../../core/wordmaker-selection/wordmaker-selection.selectors";
-import { SettingsState, State } from "../../../core/settings/settings.model";
+import {
+  HighlightAndLevel,
+  State,
+} from "../../../core/settings/settings.model";
 import { Store, select } from "@ngrx/store";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import { selectSettingsHighlightAndLevel } from "../../../core/settings/settings.selectors";
 import { ConjugationService } from "../../../core/core.module";
 import { TIERS } from "../../../../config/config";
 
@@ -21,7 +24,7 @@ import { TIERS } from "../../../../config/config";
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WordmakerConjStepComponent implements OnDestroy, OnInit {
-  settings$: Observable<SettingsState>;
+  settings$: Observable<HighlightAndLevel>;
   selection$: Observable<WordmakerState>;
   conjugation$: Observable<any>;
   unsubscribe$ = new Subject<void>();
@@ -34,7 +37,7 @@ export class WordmakerConjStepComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.settings$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectSettings)
+      select(selectSettingsHighlightAndLevel)
     );
     this.selection$ = this.store.pipe(
       takeUntil(this.unsubscribe$),

--- a/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.html
+++ b/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.html
@@ -65,22 +65,22 @@
   </div>
 
   <mat-dialog-actions>
-    <div
-      class="centered dialog__buttons__container"
-      *ngIf="selection$ | async as selection"
-    >
-      <mat-spinner *ngIf="selection.loading"></mat-spinner>
-      <button
-        *ngIf="!selection.loading"
-        class="mat-raised-button mat-primary dialog__buttons"
-        (click)="download()"
-        [matTooltip]="'ww.pages.tableviewer.dialog.download.exit' | translate"
-        [matTooltipShowDelay]="showDelay.value"
-        [matTooltipHideDelay]="hideDelay.value"
-        [matTooltipPosition]="tooltipPosition"
-      >
-        {{ "ww.pages.tableviewer.dialog.download.download" | translate }}
-      </button>
+    <div class="centered dialog__buttons__container">
+      <ng-container *ngIf="loading$ | async; else downloadButton">
+        <mat-spinner></mat-spinner>
+      </ng-container>
+      <ng-template #downloadButton>
+        <button
+          class="mat-raised-button mat-primary dialog__buttons"
+          (click)="download()"
+          [matTooltip]="'ww.pages.tableviewer.dialog.download.exit' | translate"
+          [matTooltipShowDelay]="showDelay.value"
+          [matTooltipHideDelay]="hideDelay.value"
+          [matTooltipPosition]="tooltipPosition"
+        >
+          {{ "ww.pages.tableviewer.dialog.download.download" | translate }}
+        </button>
+      </ng-template>
       <button
         (click)="exit()"
         class="exit-button dialog__buttons"

--- a/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.ts
+++ b/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.ts
@@ -15,10 +15,11 @@ import {
 } from "../../core/core.module";
 import { selectTableviewerState } from "../../core/core.state";
 import { actionSettingsChangeLevel } from "../../core/settings/settings.actions";
-import { SettingsState, State } from "../../core/settings/settings.model";
-import { selectSettings } from "../../core/settings/settings.selectors";
+import { LevelAndBaseUrl, State } from "../../core/settings/settings.model";
+import { selectSettingsLevelAndBaseUrl } from "../../core/settings/settings.selectors";
 import { actionChangeLoading } from "../../core/tableviewer-selection/tableviewer-selection.actions";
 import { TableviewerState } from "../../core/tableviewer-selection/tableviewer-selection.model";
+import { selectTableViewerLoading } from "../../core/tableviewer-selection/tableviewer-selection.selectors";
 
 @Component({
   selector: "ww-download-dialog",
@@ -28,9 +29,10 @@ import { TableviewerState } from "../../core/tableviewer-selection/tableviewer-s
 })
 export class DownloadDialogComponent implements OnInit {
   objectkeys = Object.keys;
-  settings$: Observable<SettingsState>;
+  settings$: Observable<LevelAndBaseUrl>;
   selection$: Observable<TableviewerState>;
-  selectionAndSettings$: Observable<[TableviewerState, SettingsState]>;
+  loading$: Observable<boolean>;
+  selectionAndSettings$: Observable<[TableviewerState, LevelAndBaseUrl]>;
   fileTypes = {
     list: ["docx"],
     grid: ["xlsx"],
@@ -63,7 +65,8 @@ export class DownloadDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.selection$ = this.store.pipe(select(selectTableviewerState));
-    this.settings$ = this.store.pipe(select(selectSettings));
+    this.settings$ = this.store.pipe(select(selectSettingsLevelAndBaseUrl));
+    this.loading$ = this.store.pipe(select(selectTableViewerLoading));
     this.selectionAndSettings$ = combineLatest([
       this.selection$,
       this.settings$,

--- a/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.html
+++ b/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.html
@@ -2,10 +2,10 @@
   <h2 mat-dialog-title>
     {{ "ww.pages.tableviewer.dialog.advanced.title" | translate }}
   </h2>
-  <div mat-dialog-content *ngIf="selection$ | async as selection">
+  <div mat-dialog-content *ngIf="view$ | async as view">
     <mat-radio-group
       class="radio-group"
-      [ngModel]="selection.view"
+      [ngModel]="view"
       (change)="onSelecteViewMode($event)"
     >
       <mat-radio-button

--- a/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.ts
+++ b/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.ts
@@ -4,12 +4,13 @@ import { MatDialogRef } from "@angular/material/dialog";
 import { select, Store } from "@ngrx/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
-import { META_DATA } from "../../../config/config";
-import { selectTableviewerState } from "../../core/core.state";
+import { META_DATA, TableviewerViewModes } from "../../../config/config";
 import { State } from "../../core/settings/settings.model";
 import { actionChangeViewMode } from "../../core/tableviewer-selection/tableviewer-selection.actions";
-import { TableviewerState } from "../../core/tableviewer-selection/tableviewer-selection.model";
-import { selectTableViewerGridOrder } from "../../core/tableviewer-selection/tableviewer-selection.selectors";
+import {
+  selectTableViewerGridOrder,
+  selectTableViewerView,
+} from "../../core/tableviewer-selection/tableviewer-selection.selectors";
 import { GridOrderOptions } from "../../pages/tableviewer/conjugation-grid/conjugation-grid.component";
 
 @Component({
@@ -23,7 +24,7 @@ export class TableViewerDialogComponent implements OnInit {
   hideDelay = new FormControl(200);
   tooltipPosition = "above";
   metaData = META_DATA;
-  selection$: Observable<TableviewerState>;
+  view$: Observable<TableviewerViewModes>;
   gridOrderTitles = ["Tabs", "Rows", "Columns"];
   gridOrder$;
   gridOrderValues: GridOrderOptions[];
@@ -38,7 +39,7 @@ export class TableViewerDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.selection$ = this.store.pipe(select(selectTableviewerState));
+    this.view$ = this.store.pipe(select(selectTableViewerView));
   }
 
   onSelecteViewMode(event) {

--- a/projects/word-weaver/src/app/shared/utils/tagged-array.util.ts
+++ b/projects/word-weaver/src/app/shared/utils/tagged-array.util.ts
@@ -1,0 +1,11 @@
+export interface Tagged {
+  tag: string;
+}
+
+// Order-sensitive equality check for arrays of tagged objects (Verb,
+// Pronoun, Option, ...), used to avoid producing a new state reference
+// from a reducer when a selection action's payload is semantically
+// identical to the current state.
+export const sameTagged = (a: Tagged[] = [], b: Tagged[] = []): boolean =>
+  a.length === b.length &&
+  a.every((item, index) => item?.tag === b[index]?.tag);

--- a/projects/word-weaver/tsconfig.json
+++ b/projects/word-weaver/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "files": [],
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "types": ["node", "jasmine"],
+    "noUnusedLocals": false
+  }
+}


### PR DESCRIPTION
This should fix https://github.com/WordWeaverTools/wordweaver/issues/159

There are a few main insights/fixes here:

1. Instead of select(selectSettingsState) in the verb and conjugation services we use select(selectSettingsBaseUrl) since the change of base url (aka using a different backend) is the only thing that should trigger a re-load. We also add distinctUntilChanged to guard against an unnecessary fetch. I also added this to the pronoun and options services.
2.  I also added the `sameTagged` fn (projects/word-weaver/src/app/shared/utils/tagged-array.util.ts) in line with the work in https://github.com/WordWeaverTools/wordweaver/commit/eef9ba07776380670edc74c96c89590702da0166

I used Claude Sonnet 5 to both diagnose and apply the changes here. Tested and reviewed by me.