### PR TITLE
refactor: mechanical changes throughout repo to limit how much state is consumed

### DIFF
--- a/projects/word-weaver/src/app/core/settings/settings.effects.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.effects.ts
@@ -5,13 +5,7 @@ import { Actions, createEffect, ofType } from "@ngrx/effects";
 import { select, Store } from "@ngrx/store";
 import { TranslateService } from "@ngx-translate/core";
 import { combineLatest, merge, of, timer } from "rxjs";
-import {
-  distinctUntilChanged,
-  map,
-  mapTo,
-  tap,
-  withLatestFrom,
-} from "rxjs/operators";
+import { distinctUntilChanged, map, tap, withLatestFrom } from "rxjs/operators";
 import { environment } from "../../../environments/environment";
 import { AnimationsService } from "../animations/animations.service";
 import { selectSettingsState } from "../core.state";
@@ -82,16 +76,7 @@ export class SettingsEffects {
       timer(0, 60_000),
       this.actions$.pipe(ofType(actionSettingsChangeAutoNightMode))
     ).pipe(
-      // TODO: the following mapTo() is a bug and should be replaced with:
-      //     map(() => new Date().getHours())
-      //
-      // but doing so would trigger issue #159 at the top of every hour.
-      //
-      // By maintaining this we keep a partial implementation of
-      // day/night theme toggling, without user data loss at every hour.
-      //
-      // Ref: https://github.com/WordWeaverTools/wordweaver/issues/159
-      mapTo(new Date().getHours()),
+      map(() => new Date().getHours()),
       distinctUntilChanged(),
       map((hour) => actionSettingsChangeHour({ hour }))
     )

--- a/projects/word-weaver/src/app/core/settings/settings.model.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.model.ts
@@ -37,3 +37,15 @@ export interface SettingsState {
 export interface State extends AppState {
   settings: SettingsState;
 }
+
+// Narrow, reusable slices of SettingsState for components/templates that
+// only need a couple of fields, not the whole settings object.
+export interface HighlightAndLevel {
+  highlight: Highlight;
+  level: Level;
+}
+
+export interface LevelAndBaseUrl {
+  level: Level;
+  baseUrl: string;
+}

--- a/projects/word-weaver/src/app/core/settings/settings.selectors.ts
+++ b/projects/word-weaver/src/app/core/settings/settings.selectors.ts
@@ -27,6 +27,32 @@ export const selectSettingsBaseUrl = createSelector(
   (state: SettingsState) => state.baseUrl
 );
 
+export const selectSettingsHighlight = createSelector(
+  selectSettings,
+  (state: SettingsState) => state.highlight
+);
+
+export const selectSettingsLevel = createSelector(
+  selectSettings,
+  (state: SettingsState) => state.level
+);
+
+// Combined, narrow selectors for components that only need the
+// tier-display fields (not the whole SettingsState), so unrelated
+// settings changes (theme, hour, language, ...) don't produce a new
+// reference for these and trigger avoidable re-renders/re-fetches.
+export const selectSettingsHighlightAndLevel = createSelector(
+  selectSettingsHighlight,
+  selectSettingsLevel,
+  (highlight, level) => ({ highlight, level })
+);
+
+export const selectSettingsLevelAndBaseUrl = createSelector(
+  selectSettingsLevel,
+  selectSettingsBaseUrl,
+  (level, baseUrl) => ({ level, baseUrl })
+);
+
 export const selectTheme = createSelector(
   selectSettings,
   (settings) => settings.theme

--- a/projects/word-weaver/src/app/pages/tableviewer/conjugation-grid/conjugation-grid.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/conjugation-grid/conjugation-grid.component.ts
@@ -21,8 +21,11 @@ import {
   PronounService,
   VerbService,
 } from "../../../core/core.module";
-import { SettingsState, State } from "../../../core/settings/settings.model";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import {
+  HighlightAndLevel,
+  State,
+} from "../../../core/settings/settings.model";
+import { selectSettingsHighlightAndLevel } from "../../../core/settings/settings.selectors";
 import { selectTableviewerGridSlice } from "../../../core/tableviewer-selection/tableviewer-selection.selectors";
 
 export type GridOrderOptions = "root" | "pn" | "option";
@@ -47,7 +50,7 @@ export class ConjugationGridComponent
   keys = Object.keys;
   displayTier = TIERS[0];
   tiers$: Observable<Tier[]>;
-  settings$: Observable<SettingsState>;
+  settings$: Observable<HighlightAndLevel>;
   dataSources: MatTableDataSource<Conjugations>[];
   uniqueCol: string[];
   uniqueMain: string[];
@@ -66,7 +69,7 @@ export class ConjugationGridComponent
   ngOnInit(): void {
     this.settings$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectSettings)
+      select(selectSettingsHighlightAndLevel)
     );
     this.tiers$ = this.settings$.pipe(
       takeUntil(this.unsubscribe$),

--- a/projects/word-weaver/src/app/pages/tableviewer/conjugation-list/conjugation-list.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/conjugation-list/conjugation-list.component.ts
@@ -9,8 +9,11 @@ import { select, Store } from "@ngrx/store";
 import { Observable, Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { Conjugations, TIERS } from "../../../../config/config";
-import { SettingsState, State } from "../../../core/settings/settings.model";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import {
+  HighlightAndLevel,
+  State,
+} from "../../../core/settings/settings.model";
+import { selectSettingsHighlightAndLevel } from "../../../core/settings/settings.selectors";
 
 @Component({
   selector: "ww-conjugation-list",
@@ -21,7 +24,7 @@ import { selectSettings } from "../../../core/settings/settings.selectors";
 export class ConjugationListComponent implements OnDestroy, OnInit {
   @Input() data$: Observable<Conjugations>;
 
-  settings$: Observable<SettingsState>;
+  settings$: Observable<HighlightAndLevel>;
   tiers = TIERS;
   // selection$: Observable<TableviewerState>;
   unsubscribe$ = new Subject<void>();
@@ -30,7 +33,7 @@ export class ConjugationListComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.settings$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectSettings)
+      select(selectSettingsHighlightAndLevel)
     );
   }
 

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.html
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.html
@@ -1,4 +1,4 @@
-<div class="panel" *ngIf="settings$ | async as settings">
+<div class="panel">
   <div class="panel__header__container">
     <div *ngIf="showToolbar" class="panel__header panel__header--tableview">
       <h5 #header class="panel__title">

--- a/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.ts
+++ b/projects/word-weaver/src/app/pages/tableviewer/tableviewer-conj-panel/tableviewer-conj-panel.component.ts
@@ -22,8 +22,7 @@ import {
   ROUTE_ANIMATIONS_ELEMENTS,
 } from "../../../core/core.module";
 import { actionSettingsChangeThemeColors } from "../../../core/settings/settings.actions";
-import { SettingsState, State } from "../../../core/settings/settings.model";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import { State } from "../../../core/settings/settings.model";
 import {
   actionChangeGridOrder,
   actionChangeTreeViewDepth,
@@ -64,7 +63,6 @@ export class TableviewerConjPanelComponent
   @ViewChild("header") header;
   @ViewChild("conjugate") conjugateBtn;
   // Basic config
-  settings$: Observable<SettingsState>;
   selection$: Observable<TableviewerState>;
   gridDataState$: Observable<Partial<TableviewerState>>;
   listDataState$: Observable<Partial<TableviewerState>>;
@@ -99,10 +97,6 @@ export class TableviewerConjPanelComponent
 
   ngOnInit(): void {
     // populate with store's selection
-    this.settings$ = this.store.pipe(
-      takeUntil(this.unsubscribe$),
-      select(selectSettings)
-    );
     this.selection$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
       select(selectTableviewer)

--- a/projects/word-weaver/src/app/pages/wordmaker/wordmaker-conj-step/wordmaker-conj-step.component.ts
+++ b/projects/word-weaver/src/app/pages/wordmaker/wordmaker-conj-step/wordmaker-conj-step.component.ts
@@ -8,9 +8,12 @@ import { Observable, Subject } from "rxjs";
 import { switchMap, map, takeUntil } from "rxjs/operators";
 import { WordmakerState } from "../../../core/wordmaker-selection/wordmaker-selection.model";
 import { selectWordmaker } from "../../../core/wordmaker-selection/wordmaker-selection.selectors";
-import { SettingsState, State } from "../../../core/settings/settings.model";
+import {
+  HighlightAndLevel,
+  State,
+} from "../../../core/settings/settings.model";
 import { Store, select } from "@ngrx/store";
-import { selectSettings } from "../../../core/settings/settings.selectors";
+import { selectSettingsHighlightAndLevel } from "../../../core/settings/settings.selectors";
 import { ConjugationService } from "../../../core/core.module";
 import { TIERS } from "../../../../config/config";
 
@@ -21,7 +24,7 @@ import { TIERS } from "../../../../config/config";
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WordmakerConjStepComponent implements OnDestroy, OnInit {
-  settings$: Observable<SettingsState>;
+  settings$: Observable<HighlightAndLevel>;
   selection$: Observable<WordmakerState>;
   conjugation$: Observable<any>;
   unsubscribe$ = new Subject<void>();
@@ -34,7 +37,7 @@ export class WordmakerConjStepComponent implements OnDestroy, OnInit {
   ngOnInit(): void {
     this.settings$ = this.store.pipe(
       takeUntil(this.unsubscribe$),
-      select(selectSettings)
+      select(selectSettingsHighlightAndLevel)
     );
     this.selection$ = this.store.pipe(
       takeUntil(this.unsubscribe$),

--- a/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.html
+++ b/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.html
@@ -65,22 +65,22 @@
   </div>
 
   <mat-dialog-actions>
-    <div
-      class="centered dialog__buttons__container"
-      *ngIf="selection$ | async as selection"
-    >
-      <mat-spinner *ngIf="selection.loading"></mat-spinner>
-      <button
-        *ngIf="!selection.loading"
-        class="mat-raised-button mat-primary dialog__buttons"
-        (click)="download()"
-        [matTooltip]="'ww.pages.tableviewer.dialog.download.exit' | translate"
-        [matTooltipShowDelay]="showDelay.value"
-        [matTooltipHideDelay]="hideDelay.value"
-        [matTooltipPosition]="tooltipPosition"
-      >
-        {{ "ww.pages.tableviewer.dialog.download.download" | translate }}
-      </button>
+    <div class="centered dialog__buttons__container">
+      <ng-container *ngIf="loading$ | async; else downloadButton">
+        <mat-spinner></mat-spinner>
+      </ng-container>
+      <ng-template #downloadButton>
+        <button
+          class="mat-raised-button mat-primary dialog__buttons"
+          (click)="download()"
+          [matTooltip]="'ww.pages.tableviewer.dialog.download.exit' | translate"
+          [matTooltipShowDelay]="showDelay.value"
+          [matTooltipHideDelay]="hideDelay.value"
+          [matTooltipPosition]="tooltipPosition"
+        >
+          {{ "ww.pages.tableviewer.dialog.download.download" | translate }}
+        </button>
+      </ng-template>
       <button
         (click)="exit()"
         class="exit-button dialog__buttons"

--- a/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.ts
+++ b/projects/word-weaver/src/app/shared/download-dialog/download-dialog.component.ts
@@ -15,10 +15,11 @@ import {
 } from "../../core/core.module";
 import { selectTableviewerState } from "../../core/core.state";
 import { actionSettingsChangeLevel } from "../../core/settings/settings.actions";
-import { SettingsState, State } from "../../core/settings/settings.model";
-import { selectSettings } from "../../core/settings/settings.selectors";
+import { LevelAndBaseUrl, State } from "../../core/settings/settings.model";
+import { selectSettingsLevelAndBaseUrl } from "../../core/settings/settings.selectors";
 import { actionChangeLoading } from "../../core/tableviewer-selection/tableviewer-selection.actions";
 import { TableviewerState } from "../../core/tableviewer-selection/tableviewer-selection.model";
+import { selectTableViewerLoading } from "../../core/tableviewer-selection/tableviewer-selection.selectors";
 
 @Component({
   selector: "ww-download-dialog",
@@ -28,9 +29,10 @@ import { TableviewerState } from "../../core/tableviewer-selection/tableviewer-s
 })
 export class DownloadDialogComponent implements OnInit {
   objectkeys = Object.keys;
-  settings$: Observable<SettingsState>;
+  settings$: Observable<LevelAndBaseUrl>;
   selection$: Observable<TableviewerState>;
-  selectionAndSettings$: Observable<[TableviewerState, SettingsState]>;
+  loading$: Observable<boolean>;
+  selectionAndSettings$: Observable<[TableviewerState, LevelAndBaseUrl]>;
   fileTypes = {
     list: ["docx"],
     grid: ["xlsx"],
@@ -63,7 +65,8 @@ export class DownloadDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.selection$ = this.store.pipe(select(selectTableviewerState));
-    this.settings$ = this.store.pipe(select(selectSettings));
+    this.settings$ = this.store.pipe(select(selectSettingsLevelAndBaseUrl));
+    this.loading$ = this.store.pipe(select(selectTableViewerLoading));
     this.selectionAndSettings$ = combineLatest([
       this.selection$,
       this.settings$,

--- a/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.html
+++ b/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.html
@@ -2,10 +2,10 @@
   <h2 mat-dialog-title>
     {{ "ww.pages.tableviewer.dialog.advanced.title" | translate }}
   </h2>
-  <div mat-dialog-content *ngIf="selection$ | async as selection">
+  <div mat-dialog-content *ngIf="view$ | async as view">
     <mat-radio-group
       class="radio-group"
-      [ngModel]="selection.view"
+      [ngModel]="view"
       (change)="onSelecteViewMode($event)"
     >
       <mat-radio-button

--- a/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.ts
+++ b/projects/word-weaver/src/app/shared/tableviewer-dialog/tableviewer-dialog.component.ts
@@ -4,12 +4,13 @@ import { MatDialogRef } from "@angular/material/dialog";
 import { select, Store } from "@ngrx/store";
 import { Observable } from "rxjs";
 import { take } from "rxjs/operators";
-import { META_DATA } from "../../../config/config";
-import { selectTableviewerState } from "../../core/core.state";
+import { META_DATA, TableviewerViewModes } from "../../../config/config";
 import { State } from "../../core/settings/settings.model";
 import { actionChangeViewMode } from "../../core/tableviewer-selection/tableviewer-selection.actions";
-import { TableviewerState } from "../../core/tableviewer-selection/tableviewer-selection.model";
-import { selectTableViewerGridOrder } from "../../core/tableviewer-selection/tableviewer-selection.selectors";
+import {
+  selectTableViewerGridOrder,
+  selectTableViewerView,
+} from "../../core/tableviewer-selection/tableviewer-selection.selectors";
 import { GridOrderOptions } from "../../pages/tableviewer/conjugation-grid/conjugation-grid.component";
 
 @Component({
@@ -23,7 +24,7 @@ export class TableViewerDialogComponent implements OnInit {
   hideDelay = new FormControl(200);
   tooltipPosition = "above";
   metaData = META_DATA;
-  selection$: Observable<TableviewerState>;
+  view$: Observable<TableviewerViewModes>;
   gridOrderTitles = ["Tabs", "Rows", "Columns"];
   gridOrder$;
   gridOrderValues: GridOrderOptions[];
@@ -38,7 +39,7 @@ export class TableViewerDialogComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.selection$ = this.store.pipe(select(selectTableviewerState));
+    this.view$ = this.store.pipe(select(selectTableViewerView));
   }
 
   onSelecteViewMode(event) {


### PR DESCRIPTION
Following #163 I also asked Claude to apply some mechanical changes throughout the repo to limit the amount of state that is consumed as a precaution. These changes don't actually fix any existing bugs, they just hopefully prevent the same types of errors from happening in the future since we only select the state that we need.